### PR TITLE
フィード内のリンクURLのドメインを matsue.rubyist.net を修正。

### DIFF
--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -76,4 +76,4 @@ watcher:
   notify_on_compilation_success: true
   notify_on_compilation_failure: true
 
-base_url: "http://hoge.jp"
+base_url: "http://matsue.rubyist.net"


### PR DESCRIPTION
/feed.xml 内のリンクURLのドメインを修正しました。
