### PR TITLE
レイアウトからハードコードされた年を除去。

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -51,7 +51,7 @@
     </div><!-- cont-top end -->
 
     <div id="footer">
-      <div class="copy">Copyright © 2013 <a href="https://www.facebook.com/groups/matsuerb">Matsue.rb(松江Ruby)</a>. All Rights Reserved.</div>
+      <div class="copy">Copyright © <%= Time.now.year %> <a href="https://www.facebook.com/groups/matsuerb">Matsue.rb(松江Ruby)</a>. All Rights Reserved.</div>
     </div><!--footer end-->
 
   </div><!-- site end -->


### PR DESCRIPTION
年が明けてからの更新でフッタのCopyrightの年を更新し忘れたままになるのを防ぐため、現在日付の年を自動で入れるようにしました。
