### PR TITLE
定例会のリンクにアンカーを追加。

### DIFF
--- a/content/news/2013/08/15/matsuerb_h2508.html
+++ b/content/news/2013/08/15/matsuerb_h2508.html
@@ -10,4 +10,4 @@ priority: 0.5
 ---
 
 
-　8月17日(土)に<a href="<%= relative_path_to('/about_us/') %>">松江Ruby(Matsue.rb)定例会</a>を開催します。場所は松江オープンソースラボで、時間は09:30から17:30までです。
+　8月17日(土)に<a href="<%= relative_path_to('/about_us/#matsuerb') %>">松江Ruby(Matsue.rb)定例会</a>を開催します。場所は松江オープンソースラボで、時間は09:30から17:30までです。


### PR DESCRIPTION
アンカーを付けてみました。とはいっても about_us がそんなに大きい訳ではないので見た目変わらないです。今後役に立つかも程度です。
