### PR TITLE
9/21(土)のお知らせを追加。(refs #18)

### DIFF
--- a/content/news/2013/08/18/matsuerb_h2509.html
+++ b/content/news/2013/08/18/matsuerb_h2509.html
@@ -1,0 +1,13 @@
+---
+title: 「Matsue.rb定例会H25.09」開催のお知らせ
+description: 平成25年9月21日(土)にMatsue.rb定例会H25.09を開催します。
+created_at: 2013/08/18
+kind: article
+publish: true
+tags: ["イベント"]
+changefreq: never
+priority: 0.5
+---
+
+
+　9月21日(土)に<a href="<%= relative_path_to('/about_us/#matsuerb') %>">松江Ruby(Matsue.rb)定例会</a>を開催します。場所は<a href="http://www1.city.matsue.shimane.jp/sangyoushinkou/ruby/rubycity/rabo/open.html">松江オープンソースラボ</a>で、時間は09:30から17:30までです。


### PR DESCRIPTION
9/21 のお知らせを追加。ただし、明日(8/17)の分が目立つように 8/18 のエントリとして追加しました。
なので、マージするのも今ではなく 8/18 を想定しています。

あと、テルサのところはリンク先を付けてみました。
