### PR TITLE
松江Ruby会議などの参加人数、レポート記事へのリンクを追加

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -58,8 +58,8 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H24.12    |終了    | 2012/12/08 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(308020945970668) %>|
 | Matsue.rb定例会H24.11    |終了    | 2012/11/17 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(289218707863167) %>|
 | Matsue.rb定例会H24.10    |終了    | 2012/10/20 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(344019002354189) %> |
-| 松江Ruby会議04           |終了    | 2012/09/01 10:00-17:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議04", "http://regional.rubykaigi.org/matsue04") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0040-MatsueRubyKaigi04Report")%><br/><%= link_to("OSPN記事", "http://www.ospn.jp/press/20120914osc2012-shimane-report.html") %> |
-| Matsue.rb定例会H24.09(松江Ruby会議04内)    |終了    | 2012/09/01 10:00-15:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(276110739164783) %> |
+| 松江Ruby会議04           |終了(約120名参加)| 2012/09/01 10:00-17:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議04", "http://regional.rubykaigi.org/matsue04") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0040-MatsueRubyKaigi04Report")%><br/><%= link_to("OSPN記事", "http://www.ospn.jp/press/20120914osc2012-shimane-report.html") %> |
+| Matsue.rb定例会H24.09<br />(松江Ruby会議04内)    |終了    | 2012/09/01 10:00-15:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(276110739164783) %> |
 | Matsue.rb定例会H24.08    |終了    | 2012/08/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(339245126155975) %> |
 | Matsue.rb定例会H24.07    |終了    | 2012/07/07 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(261114883994167) %> |
 | Matsue.rb定例会H24.06    |終了    | 2012/06/23 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(306595939429789) %> |
@@ -84,7 +84,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H23.10    |終了    | 2011/10/29 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(234021273313564) %> |
 | Matsue.rb定例会H23.09    |終了    | 2011/09/24 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(262547307101550) %> |
 | Matsue.rb定例会H23.08    |終了    | 2011/08/28 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(135784423175244) %> |
-| 松江Ruby会議03           |終了    | 2011/07/03 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議03", "http://regional.rubykaigi.org/matsue03") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0035-MatsueRubyKaigi03Report")%> |
+| 松江Ruby会議03           |終了(59名参加)| 2011/07/03 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議03", "http://regional.rubykaigi.org/matsue03") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0035-MatsueRubyKaigi03Report")%> |
 | Matsue.rb定例会H23.06    |終了    | 2011/06/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(136465133098778) %> |
 | Matsue.rb定例会H23.05    |終了    | 2011/05/28 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
 | Matsue.rb定例会H23.04    |終了    | 2011/04/23 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |


### PR DESCRIPTION
2013/12/05現在で判明している範囲の人数、リンクを追加してみました。

brタグの使い方がダサいかも...
