### PR TITLE
about_us.html中の松江Ruby会議05の日程を修正

### DIFF
--- a/content/about_us.html
+++ b/content/about_us.html
@@ -36,7 +36,7 @@ Matsue.rb定例会は、毎月1回、9:30から17:30まで<%= link_to_osslab %>�
 
 本イベントは、<%= link_to("地域Ruby会議(Regional RubyKaigi;りーじょなるるびーかいぎ)", "http://regional.rubykaigi.org/") %>という<%= link_to("RubyKaigi", "http://rubykaigi.org/") %>のようなイベントをいろんな地域でやってしまおうというプロジェクトの一部として開催しています。日本Rubyの会が<%= link_to("後援", "http://www.fdiary.net/ml/ruby/msg/1929") %>しています。
 
-平成25年度は1月に開催を予定していますが、まだ準備にも入っていない状況です。詳細が決まり次第、<%= link_to("Matsue.rb(松江Ruby)グループ", "https://www.facebook.com/groups/matsuerb") %>に告知する予定です。
+平成25年度は1月を予定していましたが3月15日に変更になりました。公式サイト開設までの間は<%= link_to("Matsue.rb(松江Ruby)グループ", "https://www.facebook.com/groups/matsuerb") %>に告知を行う予定です。
 
 ## グループのメンバー 一覧
 


### PR DESCRIPTION
以下の点を修正してみました。
- 日程を1月から3月15日に変更
- 公式サイト開設までの間は Facebook で告知と少し文言を変更
