### PR TITLE
出力するiCalファイル内のそれぞれのイベント中のUIDをユニークかつ、生成の度に変化する事がないように修正。

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -129,7 +129,8 @@ def generate_calendar
       event.summary = calendar[:summary]
       event.description = calendar[:description]
       event.location = calendar[:location]
-      event.uid = Time.now.strftime("%Y%m%dT%H:%M:%S+09:00_00000000@matsuerb")
+      t = Time.mktime(calendar[:year], calendar[:month], calendar[:day])
+      event.uid = t.strftime("%Y%m%dT%H:%M:%S+09:00_00000000@matsuerb")
       cal.add_event(event)
     end
   end


### PR DESCRIPTION
6月のお知らせを push したところ、iCal が iPhone では 5 月しか取り込まれない/Google カレンダーでは6月しか取り込まれない状態でした。

icalendar で生成しているので問題ないかとは思いましたが、以下で valid である事を確認しました。
- http://severinghaus.org/projects/icv/

matsuerb-nanoc でも使ってる icalendar gem で parse してみると以下のような感じだった訳ですが、これ以外で気になった点としては UID があります。

```
  $ ruby -r icalendar -e '
      cals = Icalendar.parse(ARGF)
      p cals.size # => 1
      cals.each { |cal|
        p cal.events.size # => 2
        cal.events.each { |event|
          p({summary: event.summary, dtstart: event.dtstart, uid: event.uid}) # => 5 月と 6 月が表示される。UID は共通。
        }
      }' /tmp/calendar.ics
```

フォーマットに関する公式なドキュメントを見つけられませんでしたが、5月と6月を別々に取り込みたい場合はこのPRのようにUIDを分ける必要がありそうでした。

修正後に Google カレンダーでインポートしてみたところ、2 つに分かれてインポートできました。以下は出力した ical ファイルの一部です。

```
...
UID:20140628T00:00:00+09:00_00000000@matsuerb
DTSTART:20140628T093000
DTEND:20140628T170000
DESCRIPTION:平成26年6月28日(土)にMatsue.rb定例会H26.06を開催します。
LOCATION:島根県松江市朝日町478番地18　松江テルサ別館2階
...
UID:20140531T00:00:00+09:00_00000000@matsuerb
DTSTART:20140531T093000
DTEND:20140531T170000
DESCRIPTION:平成26年5月31日(土)にMatsue.rb定例会H26.05を開催します。
LOCATION:島根県松江市朝日町478番地18　松江テルサ別館2階
SUMMARY:Matsue.rb定例会H26.05
```

2 つに分けて表示したいかどうかがこの PR を取り込むかどうかの基準になりそうです。

このままの場合は 1 つ問題がありそうで、出力の度に UID が Time.now にあわせて毎月変化しちゃうのでひょっとしたら複数個取り込まれちゃう問題があるかもしれません。その時は別の PR を作ろうかなと考えています。

どうでしょー？ > @Takashi-U
