### PR TITLE
スポンサーの表示が乱れていたので、CSSを調整しました。

### DIFF
--- a/static/matrk06/css/application.css
+++ b/static/matrk06/css/application.css
@@ -87,3 +87,8 @@ footer {
 .list-inline img {
     padding-bottom: 20px;
 }
+
+.col-xs-12 .col-xs-3{
+  width: 285px;
+  min-height: 160px;
+}


### PR DESCRIPTION
PCでブラウザの横幅を狭くして表示したり、スマホで閲覧するとスポンサーのバナーの端が見切れてしまいました。CSSを上書きしてとりあえず崩れないように調整してあります。
