### PR TITLE
中継の際のURLを準備中に変更。

### DIFF
--- a/static/matrk07/index.html
+++ b/static/matrk07/index.html
@@ -123,7 +123,7 @@
           </tr>
           <tr>
             <th>中継</th>
-            <td><a href="http://www.ustream.tv/channel/matsuerubykaigi07">動画による中継(USTREAM)</a>
+            <td>動画による中継(準備中)</a>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
今年は中継でUstreamではなくYoutubeだったので7/10時点では「準備中」に変更。@amidaku さんに確認して問題なければマージして7/10にサイトに反映しようかと思います。