### PR TITLE
Update cc content

### DIFF
--- a/layouts/_cc_to_toms_logo.html
+++ b/layouts/_cc_to_toms_logo.html
@@ -1,0 +1,1 @@
+<p>RubyロゴはRubyアソシエーションの著作物であり、Creative Commons BY-SAライセンスにより <%= link_to(url = "http://www.ruby.or.jp/ja/about/logo/", url) %> で公開されています。</p>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -60,7 +60,10 @@
         <%= link_to("お問い合わせ", "/contact/")%>｜
         <%= link_to("アクセス", "/map/")%>
       </div>
-      <p>RubyロゴはRubyアソシエーションの著作物であり、Creative Commons BY-SAライセンスにより <%= link_to(url = "http://www.ruby.or.jp/ja/about/logo/", url) %> で公開されています。</p>
+
+      <% if @item.identifier.size == 1 %>
+        <%= render('_cc_to_toms_logo') %>
+      <% end %>
       <div class="copy">Copyright © <%= copyright_year %> <a href="https://www.facebook.com/groups/matsuerb">Matsue.rb(松江Ruby) </a>. All Rights Reserved. <span><%= link_to("GitHub・matsuerb/matsuerb-nanoc", "https://github.com/matsuerb/matsuerb-nanoc", {:target => "_blank"}) %></span></div>
     </div><!--footer end-->
 

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -60,7 +60,7 @@
         <%= link_to("お問い合わせ", "/contact/")%>｜
         <%= link_to("アクセス", "/map/")%>
       </div>
-      <p>RubyロゴはRubyアソシエーションの著作物であり、Creative Commons BY-SAライセンスにより http://www.ruby.or.jp/ja/about/logo/ で公開されています。</p>
+      <p>RubyロゴはRubyアソシエーションの著作物であり、Creative Commons BY-SAライセンスにより <%= link_to(url = "http://www.ruby.or.jp/ja/about/logo/", url) %> で公開されています。</p>
       <div class="copy">Copyright © <%= copyright_year %> <a href="https://www.facebook.com/groups/matsuerb">Matsue.rb(松江Ruby) </a>. All Rights Reserved. <span><%= link_to("GitHub・matsuerb/matsuerb-nanoc", "https://github.com/matsuerb/matsuerb-nanoc", {:target => "_blank"}) %></span></div>
     </div><!--footer end-->
 

--- a/static/matrk05/index.html
+++ b/static/matrk05/index.html
@@ -518,7 +518,7 @@ RubyMotionを使ったiOSアプリ開発を実演します！</span>
       <!-- FOOTER -->
       <footer>
         <p class="text-center"><a href="http://matsue.rubyist.net/"><img src="img/h_logo.jpg" alt="matsuerb"></a></p>
-        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより https://www.ruby-lang.org/ja/about/logo/ で公開されています。</p>
+        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより <a href="https://www.ruby-lang.org/ja/about/logo/">https://www.ruby-lang.org/ja/about/logo/</a> で公開されています。</p>
       </footer>
 
     </div><!-- /.container -->

--- a/static/matrk06/index.html
+++ b/static/matrk06/index.html
@@ -422,7 +422,7 @@
       <!-- FOOTER -->
       <footer>
         <p class="text-center"><a href="http://matsue.rubyist.net/"><img src="img/h_logo.jpg" alt="matsuerb"></a></p>
-        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより https://www.ruby-lang.org/ja/about/logo/ で公開されています。</p>
+        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより <a href="https://www.ruby-lang.org/ja/about/logo/">https://www.ruby-lang.org/ja/about/logo/</a> で公開されています。</p>
       </footer>
 
     </div><!-- /.container -->

--- a/static/matrk06/ogiri.html
+++ b/static/matrk06/ogiri.html
@@ -153,7 +153,7 @@
       <!-- FOOTER -->
       <footer>
         <p class="text-center"><a href="http://matsue.rubyist.net/"><img src="img/h_logo.jpg" alt="matsuerb"></a></p>
-        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより https://www.ruby-lang.org/ja/about/logo/ で公開されています。</p>
+        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより <a href="https://www.ruby-lang.org/ja/about/logo/">https://www.ruby-lang.org/ja/about/logo/</a> で公開されています。</p>
       </footer>
 
     </div><!-- /.container -->

--- a/static/matrk07/contest.html
+++ b/static/matrk07/contest.html
@@ -146,7 +146,7 @@
     <!-- FOOTER -->
     <footer>
       <p class="text-center"><a href="http://matsue.rubyist.net/"><img src="img/h_logo.jpg" alt="matsuerb"></a></p>
-      <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより https://www.ruby-lang.org/ja/about/logo/ で公開されています。</p>
+      <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより <a href="https://www.ruby-lang.org/ja/about/logo/">https://www.ruby-lang.org/ja/about/logo/</a> で公開されています。</p>
     </footer>
     <script src="js/bootstrap.js"></script>
   </body>

--- a/static/matrk07/index.html
+++ b/static/matrk07/index.html
@@ -568,7 +568,7 @@
       <!-- FOOTER -->
       <footer>
         <p class="text-center"><a href="http://matsue.rubyist.net/"><img src="img/h_logo.jpg" alt="matsuerb"></a></p>
-        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより https://www.ruby-lang.org/ja/about/logo/ で公開されています。</p>
+        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより <a href="https://www.ruby-lang.org/ja/about/logo/">https://www.ruby-lang.org/ja/about/logo/</a> で公開されています。</p>
       </footer>
 
     </div><!-- /.container -->

--- a/static/matrk07/sponsor.html
+++ b/static/matrk07/sponsor.html
@@ -101,7 +101,7 @@
       <!-- FOOTER -->
       <footer>
         <p class="text-center"><a href="http://matsue.rubyist.net/"><img src="img/h_logo.jpg" alt="matsuerb"></a></p>
-        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより https://www.ruby-lang.org/ja/about/logo/ で公開されています。</p>
+        <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより <a href="https://www.ruby-lang.org/ja/about/logo/">https://www.ruby-lang.org/ja/about/logo/</a> で公開されています。</p>
       </footer>
 
     </div><!-- /.container -->


### PR DESCRIPTION
URLをリンクにするように修正。
main_img.jpgの表示と同じ条件でのみCC表記を行うように修正。item.raw_contentにmain_img.jpgが含まれていた場合にのみ表示しようかとも思ったけど今はやめておいた(可能な話かは確認していない)。
他にCC表記を行う事がある場合に備えてCC表記を分離。