### PR TITLE
「株式会社」と社名間のスペースを統一。

### DIFF
--- a/static/matrk07/index.html
+++ b/static/matrk07/index.html
@@ -422,7 +422,7 @@
             <div style="height: 100px;">
               <img alt='spicelife' src='img/spicelife.png' width="80%">
             </div>
-            <div>株式会社 spice life</div>
+            <div>株式会社spice life</div>
           </a>
         </div>
       </div>
@@ -475,7 +475,7 @@
             <div class="logo-wrapper">
               <img alt="tpj" src="img/tpj.jpg">
             </div>
-            <div>株式会社 テクノプロジェクト</div>
+            <div>株式会社テクノプロジェクト</div>
           </a>
         </div>
         <div class="col-xs-3 col-md-3" style="text-align: center;">
@@ -494,7 +494,7 @@
               <div class="logo-wrapper">
                 <img alt="eastback" src="img/eastback.jpg">
               </div>
-              <div>株式会社 イーストバック</div>
+              <div>株式会社イーストバック</div>
             </a>
           </div>
         </div>
@@ -504,7 +504,7 @@
               <div class="logo-wrapper">
                 <img alt="yakumo" src="img/yakumo.png">
               </div>
-              <div>株式会社 八雲ソフトウェア</div>
+              <div>株式会社八雲ソフトウェア</div>
             </a>
           </div>
         </div>
@@ -514,7 +514,7 @@
               <div class="logo-wrapper">
                 <img alt="systemlink" src="img/systemlink.png">
               </div>
-              <div>株式会社 システムリンク</div>
+              <div>株式会社システムリンク</div>
             </a>
           </div>
         </div>


### PR DESCRIPTION
「株式会社」と社名間のスペースがあるなしバラバラであったためない方に統一しました。