### PR TITLE
松江Ruby会議の開催報告へのリンクを追加。

### DIFF
--- a/content/about_us.html
+++ b/content/about_us.html
@@ -1,6 +1,6 @@
 ---
 title: 松江Rubyとは
-description: 
+description:
 keywords:
 ---
 
@@ -36,7 +36,15 @@ Matsue.rb定例会は、毎月1回、9:30から17:00まで<%= link_to_osslab %>�
 
 本イベントは、<%= link_to("地域Ruby会議(Regional RubyKaigi;りーじょなるるびーかいぎ)", "http://regional.rubykaigi.org/") %>という<%= link_to("RubyKaigi", "http://rubykaigi.org/") %>のようなイベントをいろんな地域でやってしまおうというプロジェクトの一部として開催しています。日本Rubyの会が<%= link_to("後援", "http://www.fdiary.net/ml/ruby/msg/1929") %>しています。
 
-平成27年度は9月26日を予定しています。詳細は<%= link_to("公式サイト", "/matrk07") %>をご覧ください。
+### これまでの開催
+
+* 松江Ruby会議07 (2015/09/26)
+* [松江Ruby会議06](http://magazine.rubyist.net/?0051-MatsueRubyKaigi06Report) (2014/12/30)
+* [松江Ruby会議05](http://magazine.rubyist.net/?0050-MatsueRubyKaigi05) (2014/03/25)
+* [松江Ruby会議04](http://magazine.rubyist.net/?0040-MatsueRubyKaigi04Report) (2012/09/01)
+* [松江Ruby会議03](http://magazine.rubyist.net/?0035-MatsueRubyKaigi03Report) (2011/07/03)
+* [松江Ruby会議02](http://magazine.rubyist.net/?0034-MatsueRubyKaigi02Report) (2010/02/13)
+* [松江Ruby会議01](http://magazine.rubyist.net/?0026-MatsueRubyKaigi01Report) (2009/02/02)
 
 ## グループのメンバー 一覧
 


### PR DESCRIPTION
セクション「松江Ruby会議について」で、るびまに掲載されている過去の開催報告へのリンクを追加してみました。