### PR TITLE
松江Ruby会議08のお問い合わせ先のメールアドレスを修正

### DIFF
--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -363,7 +363,7 @@
         <blockquote>
           <h2 class="font-Fenix" id="message">お問い合わせ</h2>
         </blockquote>
-        <p class="main-text font-Fenix">松江Ruby会議08に関するお問い合わせは、matsuerubykaigi08 _at_ googlegroups.comまでメールにてご連絡ください。</p>
+        <p class="main-text font-Fenix">松江Ruby会議08に関するお問い合わせは、matsuerubykaigi _at_ googlegroups.comまでメールにてご連絡ください。</p>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
https://github.com/matsuerb/matrk/issues/60

松江Ruby会議08から番号を外したメールアドレスを使用するとのことでした。