### PR TITLE
松江Ruby会議08のスポンサーの表示を修正

### DIFF
--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -510,7 +510,7 @@
         <div class="logo-wrapper">
           <img alt="tm-21" src="img/tm-21.jpg">
         </div>
-        <div>ティーエム21</div>
+        <div>株式会社 ティーエム21</div>
       </a>
     </div>
 


### PR DESCRIPTION
株式会社の表示を修正しました。
公式サイトの会社概要と松江Ruby会議07の表示を参考にしました。

http://www.tm-21.co.jp/company/57

https://github.com/matsuerb/matsuerb-nanoc/issues/404