### PR TITLE
松江Ruby会議08にスポンサーを追加

### DIFF
--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -524,6 +524,15 @@
     </div>
 
     <div class="col-xs-3 col-md-3" style="text-align: center;">
+      <a href="http://www.fenrir-inc.com/" target="_blank">
+        <div class="logo-wrapper">
+          <img alt="fenrir" src="img/fenrir.jpg">
+        </div>
+        <div>フェンリル株式会社</div>
+      </a>
+    </div>
+
+    <div class="col-xs-3 col-md-3" style="text-align: center;">
       <a href="https://www.misoca.jp/" target="_blank">
         <div class="logo-wrapper">
           <img alt="misoca" src="img/misoca.png">


### PR DESCRIPTION
決裁が下りたと聞いたので、いただいたロゴ画像をスポンサーに追加しました。

https://github.com/matsuerb/matsuerb-nanoc/issues/404