### PR TITLE
松江Ruby会議08の懇親会へのリンクを追加

### DIFF
--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -445,9 +445,14 @@
           <h2 class="font-Fenix" id="message">参加登録の案内</h2>
         </blockquote>
         <p class="main-text font-Fenix">カンファレンスの参加費は無料ですが人数把握のため事前登録をお願いします。</p>
-        <p class="main-text font-Fenix">講演後に懇親会を予定にしておりますのが現在準備中のためしばらくお待ちください。</p>
+        <p class="main-text font-Fenix">講演後に懇親会を予定にしておりますので合わせて事前登録をお願いします。</p>
+        <p class="main-text font-Fenix">なお懇親会（学生）については人数に限りがありますのでお早めにエントリください！</p>
         <a href="https://matsue-rb.doorkeeper.jp/events/52118" target="_blank">
         <button class="button" type="button">参加受付</button></a>
+        <a href="https://matsue-rb.doorkeeper.jp/events/52119" target="_blank">
+        <button class="button" type="button">懇親会(一般)</button></a>
+        <a href="https://matsue-rb.doorkeeper.jp/events/54248" target="_blank">
+        <button class="button" type="button">懇親会(学生)</button></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
松江Ruby会議08の公式サイトから懇親会のDoorkeeperへのリンクを修正しました。