### PR TITLE
松江Ruby会議08の講演者ご紹介にSNSのリンクを追加

### DIFF
--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -257,6 +257,10 @@
                 <span class="person matz"></span>
                 <div class="profile">
                   <span class="name">まつもとゆきひろ氏</span>
+                  <span class="social">
+                    <a href="https://twitter.com/yukihiro_matz" class="twitter"></a>
+                    <a href="https://github.com/matz" class="github"></a>
+                  </span>
                   <p class="description">
                     我らがRubyの生みの親。小泉八雲氏と肩を並べて松江市名誉市民でもあり、Rubyを通して地方から世界のソフトウェア業界に多大な影響を与えています。今回も松江ならでは、基調講演でお話をしていただきます。
                   </p>
@@ -266,6 +270,10 @@
                 <span class="person matsuda"></span>
                 <div class="profile">
                   <span class="name">松田明氏</span>
+                  <span class="social">
+                    <a href="https://twitter.com/a_matsuda" class="twitter"></a>
+                    <a href="https://github.com/amatsuda" class="github"></a>
+                  </span>
                   <p class="description">
                     Ruby、Railsのコミッター。RailsでWeb開発をしたことがある人なら誰もが一度は使ったことがある、KaminariやCarrierWaveの開発者でもあります。また、Asakusa.rbの創設者でもあります。
                   </p>


### PR DESCRIPTION
講演者ご紹介のSNSのリンクがなかったので追加しました。