### PR TITLE
IE9の表示のためのタグを削除

### DIFF
--- a/static/matrk05/index.html
+++ b/static/matrk05/index.html
@@ -11,14 +11,6 @@
     <meta property="og:description" content="松江Ruby会議 05 2014 ― 3月15日（土）オープンソースラボにて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
-    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" href="css/carousel.css">
     <link rel="stylesheet" href="css/application.css">
     <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>

--- a/static/matrk06/index.html
+++ b/static/matrk06/index.html
@@ -11,14 +11,6 @@
     <meta property="og:description" content="松江Ruby会議 06 2014 ― 12月20日（土）オープンソースラボにて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
-    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" href="css/carousel.css">
     <link rel="stylesheet" href="css/application.css">
     <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>

--- a/static/matrk06/ogiri.html
+++ b/static/matrk06/ogiri.html
@@ -11,14 +11,6 @@
     <meta property="og:description" content="松江Ruby会議 06 2014 ― 12月20日（土）オープンソースラボにて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
-    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" href="css/carousel.css">
     <link rel="stylesheet" href="css/application.css">
     <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>

--- a/static/matrk07/contest.html
+++ b/static/matrk07/contest.html
@@ -11,14 +11,6 @@
     <meta property="og:description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4">
     <link rel="stylesheet" href="css/bootstrap.css">
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
-    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" href="css/carousel.css">
     <link rel="stylesheet" href="css/application.css">
     <link rel="stylesheet" href="css/contest.css">

--- a/static/matrk07/index.html
+++ b/static/matrk07/index.html
@@ -12,14 +12,6 @@
     <meta property="og:description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4">
     <link rel="stylesheet" href="css/bootstrap.css">
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
-    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" href="css/carousel.css">
     <link rel="stylesheet" href="css/application.css">
     <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>

--- a/static/matrk07/sponsor.html
+++ b/static/matrk07/sponsor.html
@@ -11,14 +11,6 @@
     <meta property="og:description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
-    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" href="css/carousel.css">
     <link rel="stylesheet" href="css/application.css">
     <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>

--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -12,14 +12,6 @@
     <meta property="og:description" content="松江Ruby会議 08 2016 ―12月17日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4">
     <link rel="stylesheet" href="css/bootstrap.css">
-    <!-- Just for debugging purposes. Don't actually copy this line! -->
-    <!--[if lt IE 9]><script src="../../docs-assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" href="css/carousel.css">
     <link rel="stylesheet" href="css/application.css">
     <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>


### PR DESCRIPTION
サポートが切れたIE9は対象ブラウザから外しても良いと思うので、IE9のタグを削除しました。