### PR TITLE
カンファレンス名の表記ゆれを修正

### DIFF
--- a/static/matrk05/index.html
+++ b/static/matrk05/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>松江Ruby会議 05</title>
-    <meta name="description" content="松江Ruby会議 05 2014 ― 3月15日（土）オープンソースラボにて開催。">
-    <meta property="og:title" content="松江Ruby会議 05">
+    <title>松江Ruby会議05</title>
+    <meta name="description" content="松江Ruby会議05 2014 ― 3月15日（土）オープンソースラボにて開催。">
+    <meta property="og:title" content="松江Ruby会議05">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="松江Ruby会議 05 2014 ― 3月15日（土）オープンソースラボにて開催。">
+    <meta property="og:description" content="松江Ruby会議05 2014 ― 3月15日（土）オープンソースラボにて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/carousel.css">

--- a/static/matrk06/index.html
+++ b/static/matrk06/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>松江Ruby会議 06</title>
-    <meta name="description" content="松江Ruby会議 06 2014 ― 12月20日（土）オープンソースラボにて開催。">
-    <meta property="og:title" content="松江Ruby会議 06">
+    <title>松江Ruby会議06</title>
+    <meta name="description" content="松江Ruby会議06 2014 ― 12月20日（土）オープンソースラボにて開催。">
+    <meta property="og:title" content="松江Ruby会議06">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="松江Ruby会議 06 2014 ― 12月20日（土）オープンソースラボにて開催。">
+    <meta property="og:description" content="松江Ruby会議06 2014 ― 12月20日（土）オープンソースラボにて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/carousel.css">

--- a/static/matrk06/ogiri.html
+++ b/static/matrk06/ogiri.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>松江Ruby会議 06</title>
-    <meta name="description" content="松江Ruby会議 06 2014 ― 12月20日（土）オープンソースラボにて開催。">
-    <meta property="og:title" content="松江Ruby会議 06">
+    <title>松江Ruby会議06</title>
+    <meta name="description" content="松江Ruby会議06 2014 ― 12月20日（土）オープンソースラボにて開催。">
+    <meta property="og:title" content="松江Ruby会議06">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="松江Ruby会議 06 2014 ― 12月20日（土）オープンソースラボにて開催。">
+    <meta property="og:description" content="松江Ruby会議06 2014 ― 12月20日（土）オープンソースラボにて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/carousel.css">

--- a/static/matrk07/contest.html
+++ b/static/matrk07/contest.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>松江Ruby会議 07 - コンテスト</title>
-    <meta name="description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
-    <meta property="og:title" content="松江Ruby会議 07 - コンテスト">
+    <title>松江Ruby会議07 - コンテスト</title>
+    <meta name="description" content="松江Ruby会議07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
+    <meta property="og:title" content="松江Ruby会議07 - コンテスト">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
+    <meta property="og:description" content="松江Ruby会議07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4">
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/carousel.css">

--- a/static/matrk07/index.html
+++ b/static/matrk07/index.html
@@ -4,12 +4,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>松江Ruby会議 07</title>
-    <meta name="description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
-    <meta property="og:title" content="松江Ruby会議 07">
+    <title>松江Ruby会議07</title>
+    <meta name="description" content="松江Ruby会議07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
+    <meta property="og:title" content="松江Ruby会議07">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
+    <meta property="og:description" content="松江Ruby会議07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4">
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/carousel.css">

--- a/static/matrk07/sponsor.html
+++ b/static/matrk07/sponsor.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>松江Ruby会議 07</title>
-    <meta name="description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
-    <meta property="og:title" content="松江Ruby会議 07">
+    <title>松江Ruby会議07</title>
+    <meta name="description" content="松江Ruby会議07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
+    <meta property="og:title" content="松江Ruby会議07">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="松江Ruby会議 07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
+    <meta property="og:description" content="松江Ruby会議07 2015 ― 9月26日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4"> 
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/carousel.css">

--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -4,12 +4,12 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>松江Ruby会議 08</title>
-    <meta name="description" content="松江Ruby会議 08 2016 ―12月17日（土）松江テルサ４階にて開催。">
-    <meta property="og:title" content="松江Ruby会議 08">
+    <title>松江Ruby会議08</title>
+    <meta name="description" content="松江Ruby会議08 2016 ―12月17日（土）松江テルサ４階にて開催。">
+    <meta property="og:title" content="松江Ruby会議08">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="松江Ruby会議 08 2016 ―12月17日（土）松江テルサ４階にて開催。">
+    <meta property="og:description" content="松江Ruby会議08 2016 ―12月17日（土）松江テルサ４階にて開催。">
     <meta name="generator" content="nanoc 3.6.4">
     <link rel="stylesheet" href="css/bootstrap.css">
     <link rel="stylesheet" href="css/carousel.css">


### PR DESCRIPTION
[公式サイト](http://matsue.rubyist.net/matrk08/)を眺めていたら、主に本文では`松江Rugy会議08`なのですが、タイトルなどmeta情報が`松江Ruby会議 08`だったので、どちらが正しいのでしょうか？

という確認プルリクです。