### PR TITLE
松江Ruby会議08の開催概要に中継を追加

### DIFF
--- a/static/matrk08/index.html
+++ b/static/matrk08/index.html
@@ -97,6 +97,10 @@
             <th>公式タグ</th>
             <td>Twitter: <a href="https://twitter.com/search?q=matrk08&src=typd&f=realtime">#matrk08</a></td>
           </tr>
+          <tr>
+            <th>中継</th>
+            <td>YouTube: <a href="https://youtu.be/I1kwzu1U80Y">松江Ruby会議08</a></td>
+          </tr>
         </table>
       </div>
 


### PR DESCRIPTION
開催概要に中継を追加しました。