### PR TITLE
bundler-auditの追加とrackの更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "guard-nanoc"
 gem "adsf"
 gem "minigit"
 gem "icalendar"
+gem "bundler-audit"
 
 group :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    rack (1.5.2)
+    rack (2.0.4)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.4)
       ffi (>= 0.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,9 @@ GEM
     adsf (1.2.0)
       rack (>= 1.0.0)
     builder (3.2.2)
+    bundler-audit (0.6.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     celluloid-io (0.15.0)
@@ -66,6 +69,7 @@ PLATFORMS
 DEPENDENCIES
   adsf
   builder
+  bundler-audit
   guard
   guard-nanoc
   icalendar


### PR DESCRIPTION
bundler-auditを追加して以下の警告を確認、rackを更新した。

```
$ bundle exec bundle-audit check
Name: rack
Version: 1.5.2
Advisory: CVE-2015-3225
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/gcUbICUmKMc
Title: Potential Denial of Service Vulnerability in Rack
Solution: upgrade to >= 1.6.2, ~> 1.5.4, ~> 1.4.6

Vulnerabilities found!
```