### PR TITLE
るびまのURL変更に追従。(fix #479)

### DIFF
--- a/content/about_us.html
+++ b/content/about_us.html
@@ -40,14 +40,14 @@ Matsue.rb定例会は、毎月1回、9:30から17:00まで<%= link_to_osslab %>�
 
 ### これまでの開催
 
-* [松江Ruby会議08](http://magazine.rubyist.net/?0056-MatsueRubyKaigi08Report) (2016/12/17)
-* [松江Ruby会議07](http://magazine.rubyist.net/?0052-MatsueRubyKaigi07Report) (2015/09/26)
-* [松江Ruby会議06](http://magazine.rubyist.net/?0051-MatsueRubyKaigi06Report) (2014/12/30)
-* [松江Ruby会議05](http://magazine.rubyist.net/?0050-MatsueRubyKaigi05) (2014/03/25)
-* [松江Ruby会議04](http://magazine.rubyist.net/?0040-MatsueRubyKaigi04Report) (2012/09/01)
-* [松江Ruby会議03](http://magazine.rubyist.net/?0035-MatsueRubyKaigi03Report) (2011/07/03)
-* [松江Ruby会議02](http://magazine.rubyist.net/?0034-MatsueRubyKaigi02Report) (2010/02/13)
-* [松江Ruby会議01](http://magazine.rubyist.net/?0026-MatsueRubyKaigi01Report) (2009/02/02)
+* [松江Ruby会議08](https://magazine.rubyist.net/articles/0056/0056-MatsueRubyKaigi08Report.html) (2016/12/17)
+* [松江Ruby会議07](https://magazine.rubyist.net/articles/0052/0052-MatsueRubyKaigi07Report.html) (2015/09/26)
+* [松江Ruby会議06](https://magazine.rubyist.net/articles/0051/0051-MatsueRubyKaigi06Report.html) (2014/12/30)
+* [松江Ruby会議05](https://magazine.rubyist.net/articles/0050/0050-MatsueRubyKaigi05.html) (2014/03/25)
+* [松江Ruby会議04](https://magazine.rubyist.net/articles/0040/0040-MatsueRubyKaigi04Report.html) (2012/09/01)
+* [松江Ruby会議03](https://magazine.rubyist.net/articles/0035/0035-MatsueRubyKaigi03Report.html) (2011/07/03)
+* [松江Ruby会議02](https://magazine.rubyist.net/articles/0034/0034-MatsueRubyKaigi02Report.html) (2010/02/13)
+* [松江Ruby会議01](https://magazine.rubyist.net/articles/0026/0026-MatsueRubyKaigi01Report.html) (2009/02/02)
 
 ## グループのメンバー 一覧
 

--- a/content/news/2015/02/28/matsue-rubykaigi06.html
+++ b/content/news/2015/02/28/matsue-rubykaigi06.html
@@ -40,4 +40,4 @@ priority: 0.5
 
 ### レポート
 
-* <%= link_to("RegionalRubyKaigi レポート (51) 松江 Ruby 会議 06", "http://magazine.rubyist.net/?0051-MatsueRubyKaigi06Report", target: "_blank") %>
+* <%= link_to("RegionalRubyKaigi レポート (51) 松江 Ruby 会議 06", "https://magazine.rubyist.net/articles/0051/0051-MatsueRubyKaigi06Report.html", target: "_blank") %>

--- a/content/news/2016/03/19/matsue-rubykaigi07.html
+++ b/content/news/2016/03/19/matsue-rubykaigi07.html
@@ -33,4 +33,4 @@ priority: 0.5
 
 ### レポート
 
-* <%= link_to("RegionalRubyKaigi レポート (55) 松江 Ruby 会議 07", "http://magazine.rubyist.net/?0052-MatsueRubyKaigi07Report", target: "_blank") %>
+* <%= link_to("RegionalRubyKaigi レポート (55) 松江 Ruby 会議 07", "https://magazine.rubyist.net/articles/0052/0052-MatsueRubyKaigi07Report.html", target: "_blank") %>

--- a/content/schedule.html
+++ b/content/schedule.html
@@ -86,7 +86,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H27.12(#68) | 終了(21名参加) | 2015/12/26 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1002152419848347) %> |
 | Matsue.rb定例会H27.11(#67) | 終了(20名参加) | 2015/11/28 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1636150683321966) %> |
 | Matsue.rb定例会H27.10(#66) | 終了(27名参加) | 2015/10/24 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1723821987841280) %> |
-| 松江Ruby会議07        | 終了(66名参加) | 2015/09/26 11:00-17:10| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議07", "/matrk07") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0052-MatsueRubyKaigi07Report")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/895041") %><br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPBSYjO2enmqSTpucHuHiA9S") %> |
+| 松江Ruby会議07        | 終了(66名参加) | 2015/09/26 11:00-17:10| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議07", "/matrk07") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0052/0052-MatsueRubyKaigi07Report.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/895041") %><br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPBSYjO2enmqSTpucHuHiA9S") %> |
 | Matsue.rb定例会H27.08(#65) | 終了(24名参加) | 2015/08/29 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(109595892707985) %> |
 | Matsue.rb定例会H27.07(#64) | 終了(25名参加) | 2015/07/25 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1499240573634239) %> |
 | Matsue.rb定例会H27.06(#63) | 終了(26名参加) | 2015/06/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(342643939277249) %> |
@@ -125,7 +125,7 @@ end
 
 |イベント名                |状態          |日時                   |会場                    |事前登録|料金|リンク                      |
 |--------------------------|--------------|-----------------------|------------------------|--------|----|----------------------------|
-| 松江Ruby会議06           |終了(57名参加)| 2014/12/20 13:00-17:45| <%= link_to_osslab %>  | 必要   |無料| <%= link_to("松江Ruby会議06", "/matrk06") %><br/><%= link_to("るびま記事", "http://magazine.rubyist.net/?0051-MatsueRubyKaigi06Report")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/760234") %><br />Flickr(<%= create_links(photos) %>)<br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPDCF_KeFc-U5W4XdmTYWPVd") %> |
+| 松江Ruby会議06           |終了(57名参加)| 2014/12/20 13:00-17:45| <%= link_to_osslab %>  | 必要   |無料| <%= link_to("松江Ruby会議06", "/matrk06") %><br/><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0051/0051-MatsueRubyKaigi06Report.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/760234") %><br />Flickr(<%= create_links(photos) %>)<br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPDCF_KeFc-U5W4XdmTYWPVd") %> |
 | Matsue.rb定例会H26.11(#57)<br/>(<%= link_to_sproutrb(event_id: 17153) %>,<br/><%= link_to_dojo(event_id: 16083) %>と同時開催) |終了(27名参加)| 2014/11/15 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(1452701574977672) %> |
 | Matsue.rb定例会H26.10(#56)<br/>(<%= link_to_sproutrb(event_id: 16353) %>,<br/><%= link_to_dojo(event_id: 15973) %>と同時開催) |終了(21名参加)| 2014/10/25 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(778993778798159) %> |
 | Matsue.rb定例会H26.09(#55)<br/>(<%= link_to_sproutrb(event_id: 15390) %> と同時開催)    |終了(18名参加)| 2014/09/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(732882966770439) %> |
@@ -134,7 +134,7 @@ end
 | Matsue.rb定例会H26.06(#52)<br/>(<%= link_to_sproutrb(event_id: 11019) %> と同時開催) |終了(22名参加)| 2014/06/28 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(761156757242034) %> |
 | Matsue.rb定例会H26.05(#51)    |終了(13名参加)| 2014/05/31 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(351258431683303) %> |
 | Matsue.rb定例会H26.04(#50)    |終了(15名参加)| 2014/04/26 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(745294255504952) %> |
-| 松江Ruby会議05                |終了(午前33名、午後40名参加)| 2014/03/15 11:00-13:00<br />2014/03/15 13:25-19:30<br /> | <%= link_to_osslab %> | 必要   |無料| <%= link_to("松江Ruby会議05", "/matrk05") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0050-MatsueRubyKaigi05")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/642795") %><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi05") %> |
+| 松江Ruby会議05                |終了(午前33名、午後40名参加)| 2014/03/15 11:00-13:00<br />2014/03/15 13:25-19:30<br /> | <%= link_to_osslab %> | 必要   |無料| <%= link_to("松江Ruby会議05", "/matrk05") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0050/0050-MatsueRubyKaigi05.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/642795") %><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi05") %> |
 | Matsue.rb定例会H26.02(#49)    |終了(24名参加)| 2014/02/08 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(605450046180950) %> |
 | Matsue.rb定例会H26.01(#48)    |終了(18名参加)| 2014/01/11 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(508877202553007) %> |
 
@@ -174,7 +174,7 @@ end
 | Matsue.rb定例会H24.12(#35)|終了    | 2012/12/08 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(308020945970668) %>|
 | Matsue.rb定例会H24.11(#34)|終了    | 2012/11/17 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(289218707863167) %>|
 | Matsue.rb定例会H24.10(#33)|終了    | 2012/10/20 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(344019002354189) %> |
-| 松江Ruby会議04           |終了(約120名参加)| 2012/09/01 10:00-17:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議04", "http://regional.rubykaigi.org/matsue04") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0040-MatsueRubyKaigi04Report")%><br/><%= link_to("OSPN記事", "http://www.ospn.jp/press/20120914osc2012-shimane-report.html") %><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/osc-2012-shimane") %> |
+| 松江Ruby会議04           |終了(約120名参加)| 2012/09/01 10:00-17:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議04", "http://regional.rubykaigi.org/matsue04") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0040/0040-MatsueRubyKaigi04Report.html")%><br/><%= link_to("OSPN記事", "http://www.ospn.jp/press/20120914osc2012-shimane-report.html") %><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/osc-2012-shimane") %> |
 | Matsue.rb定例会H24.09(#32)<br />(松江Ruby会議04内)    |終了    | 2012/09/01 10:00-15:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(276110739164783) %> |
 | Matsue.rb定例会H24.08(#31)|終了    | 2012/08/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(339245126155975) %> |
 | Matsue.rb定例会H24.07(#30)|終了    | 2012/07/07 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(261114883994167) %> |
@@ -200,7 +200,7 @@ end
 | Matsue.rb定例会H23.10(#21)|終了    | 2011/10/29 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(234021273313564) %> |
 | Matsue.rb定例会H23.09(#20)|終了    | 2011/09/24 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(262547307101550) %> |
 | Matsue.rb定例会H23.08(#19)|終了    | 2011/08/28 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(135784423175244) %> |
-| 松江Ruby会議03            |終了(59名参加)| 2011/07/03 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議03", "http://regional.rubykaigi.org/matsue03") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0035-MatsueRubyKaigi03Report")%><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi03") %> |
+| 松江Ruby会議03            |終了(59名参加)| 2011/07/03 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議03", "http://regional.rubykaigi.org/matsue03") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0035/0035-MatsueRubyKaigi03Report.html")%><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi03") %> |
 | Matsue.rb定例会H23.06(#18)|終了    | 2011/06/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(136465133098778) %> |
 | Matsue.rb定例会H23.05(#17)|終了    | 2011/05/28 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
 | Matsue.rb定例会H23.04(#16)|終了    | 2011/04/23 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
@@ -227,7 +227,7 @@ end
 | Matsue.rb定例会H22.05(#07) |終了(9名参加) | 2010/05/23 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
 | Matsue.rb定例会H22.04(#06) |終了    | 2010/04/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
 | Matsue.rb定例会H22.03(#05) |終了    | 2010/03/20 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
-| 松江Ruby会議02            |終了(74名参加)| 2010/02/13 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議02", "http://regional.rubykaigi.org/matsue02") %><br /><%= link_to("るびま記事", "http://magazine.rubyist.net/?0034-MatsueRubyKaigi02Report")%><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi02") %> |
+| 松江Ruby会議02            |終了(74名参加)| 2010/02/13 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議02", "http://regional.rubykaigi.org/matsue02") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0034/0034-MatsueRubyKaigi02Report.html")%><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi02") %> |
 
 
 </div>


### PR DESCRIPTION
いずれのリンクでもURLの変更を促す警告が表示されない事を確認した。