### PR TITLE
松江Ruby会議09の開催目的を修正

### DIFF
--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -101,8 +101,8 @@ publish: true
   </div>
   <div class="row">
     <div class="col-xs-12 col-md-8">
-      <p class="main-text font-Fenix">ゲスト講演などを通して、オープンソースへの関わりや貢献について考える機会になればと思っています。</p>
-      <p class="main-text font-Fenix">また、コードにスポットを当てた発表を通して、参加者にRubyの楽しさを知ってもらいたいと思っています。</p>
+      <p class="main-text font-Fenix">ゲスト講演を通して松江Rubyの歴史を振り返り、当たり前のようにRubyが使えることのありがたさを再認識する機会になればと思っています。</p>
+      <p class="main-text font-Fenix">また、島根のエンジニアの発表を通して、参加者にRubyの楽しさを知ってもらいたいと思っています。</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
松江Ruby会議09の開催目的を以下に修正しました。

https://github.com/matsuerb/matrk/issues/108