### PR TITLE
松江Ruby会議09にDoorkeeperの参加登録のボタンを追加

### DIFF
--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -337,18 +337,6 @@ publish: true
 
 <br><br>
 
-<div id="speaker" class="container">
-  <div class="row">
-    <div class="col-xs-12 col-md-12">
-      <p>LTのスピーカーを現在募集しております！</p>
-      <p>LTは <strong>ひと枠5分</strong> です。</p>
-      <p>詳しい内容についてはメールにて<a href="#support">お問い合わせ</a>ください。</p>
-    </div>
-  </div>
-</div>
-
-<br><br>
-
 <div id="sponser" class="container">
   <div class="row">
     <div class="col-xs-12 col-md-12">

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -328,8 +328,9 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">参加登録の案内</h2>
       </blockquote>
-      <p class="main-text font-Fenix">参加登録および懇親会の募集はDoorkeeperで行う予定としております。</p>
-      <p class="main-text font-Fenix">募集内容について現在準備中のためしばらくお待ち下さい！</p>
+      <p class="main-text font-Fenix">カンファレンスの参加費は無料ですが人数把握のため事前登録をお願いします。</p>
+      <a href="https://matsue-rb.doorkeeper.jp/events/74091" target="_blank">
+      <button class="button" type="button">参加受付</button></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
松江Ruby会議09にDoorkeeperの参加登録のボタンを追加しました。
LTで話す人は決定したとのことでしたので、LTの募集は削除しました。