### PR TITLE
Matsue.rb定例会のスケジュールの平成30年の日時の年を修正

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -19,14 +19,14 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 
 |イベント名                  |状態          |日時                   |会場                    |事前登録|料金|リンク                      |
 |----------------------------|--------------|-----------------------|------------------------|--------|----|----------------------------|
-| Matsue.rb定例会H30.08(#99) | 準備中 | 2017/08/18 13:30-17:00 | <%= link_to_terrsa %> 4F 研修室2 | 不要   |検討中| 準備中|
-| Matsue.rb定例会H30.07(#98) | 準備中 | 2017/07/21 13:30-17:00 | <%= link_to_terrsa %> 4F 研修室2 | 不要   |検討中| 準備中|
-| Matsue.rb定例会H30.06(#97) | 参加受付中 | 2017/06/23 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 75223) %> |
-| Matsue.rb定例会H30.05(#96) | 終了(23名参加) | 2017/05/26 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 73573) %> |
-| Matsue.rb定例会H30.04(#95) | 終了(19名参加) | 2017/04/21 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 72428) %> |
-| Matsue.rb定例会H30.03(#94) | 終了(21名参加) | 2017/03/24 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 70958) %> |
-| Matsue.rb定例会H30.02(#93) | 終了(11名参加) | 2017/02/18 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 70050) %> |
-| Matsue.rb定例会H30.01(#92) | 終了(13名参加) | 2017/01/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 68511) %> |
+| Matsue.rb定例会H30.08(#99) | 準備中 | 2018/08/18 13:30-17:00 | <%= link_to_terrsa %> 4F 研修室2 | 不要   |検討中| 準備中|
+| Matsue.rb定例会H30.07(#98) | 準備中 | 2018/07/21 13:30-17:00 | <%= link_to_terrsa %> 4F 研修室2 | 不要   |検討中| 準備中|
+| Matsue.rb定例会H30.06(#97) | 参加受付中 | 2018/06/23 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 75223) %> |
+| Matsue.rb定例会H30.05(#96) | 終了(23名参加) | 2018/05/26 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 73573) %> |
+| Matsue.rb定例会H30.04(#95) | 終了(19名参加) | 2018/04/21 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 72428) %> |
+| Matsue.rb定例会H30.03(#94) | 終了(21名参加) | 2018/03/24 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 70958) %> |
+| Matsue.rb定例会H30.02(#93) | 終了(11名参加) | 2018/02/18 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 70050) %> |
+| Matsue.rb定例会H30.01(#92) | 終了(13名参加) | 2018/01/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 68511) %> |
 
 
 ## 平成29年


### PR DESCRIPTION
Matsue.rb定例会のスケジュールの平成30年の日時の年を「2017年 -> 2018年」に修正しました。