### PR TITLE
松江Ruby会議09のタイムテーブルのRuby Quizの表示を修正

### DIFF
--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -417,7 +417,7 @@ publish: true
               <span>16:30 〜 17:15</span>
             </td>
             <td class="timetable-time">
-              <span>Rubyクイズ</span>
+              <span>Ruby Quiz</span>
             </td>
             <td class="timetable-time">
               <span>-</span>


### PR DESCRIPTION
倉橋さんからRuby Quizの表示が英語になっていないとのでしたので修正しました。