### PR TITLE
松江Ruby会議09のスピーカーとLTをタイムテーブルに統合する変更

### DIFF
--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -412,7 +412,7 @@ publish: true
             </td>
             <td class="timetable-time">
               <span>
-                しまねソフト研究開発センター<br />
+                ITOC しまねソフト研究開発センター<br />
                 東裕人 氏
               </span>
             </td>

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -352,7 +352,7 @@ publish: true
             <td class="timetable-time">
               <span>
                 session 1<br />
-                「RedmineサーバのおもりをするついでにRedmineで色々遊んでみた(仮)」
+                「RedmineサーバのおもりをするついでにRedmineで色々遊んでみた」
               </span>
             </td>
             <td class="timetable-time">

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -174,86 +174,6 @@ publish: true
 
   <div class="row">
     <div class="col-xs-12 col-md-12">
-
-      <h3>スピーカー</h3>
-
-      <br>
-
-      <table class="timetable-table">
-        <thead>
-        <tr>
-          <th class="timetable-date col-xs-5">タイトル</th>
-          <th class="timetable-date col-xs-3">名前</th>
-          <th class="timetable-date col-xs-4">所属</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-          <td class="timetable-time">僕とMastodon</td>
-          <td class="timetable-time">平岡 瞬</td>
-          <td class="timetable-time">ゲームリンクス</td>
-        </tr>
-        <tr>
-          <td class="timetable-time">RedmineサーバのおもりをするついでにRedmineで色々遊んでみた</td>
-          <td class="timetable-time">橋本 将</td>
-          <td class="timetable-time">株式会社ネットワーク応用通信研究所（NaCl）</td>
-        </tr>
-        <tr>
-          <td class="timetable-time">若手エンジニア ＋ Rubyプロジェクト = ？？？</td>
-          <td class="timetable-time">石川瑞希</td>
-          <td class="timetable-time">ファーエンドテクノロジー株式会社</td>
-        </tr>
-        <tr>
-          <td class="timetable-time">後方互換の保ち方</td>
-          <td class="timetable-time">日高克也</td>
-          <td class="timetable-time">株式会社Misoca</td>
-        </tr>
-        <tr>
-          <td class="timetable-time">Yet Another Ruby Application Framework "Alone"</td>
-          <td class="timetable-time">東裕人</td>
-          <td class="timetable-time">しまねソフト研究開発センター</td>
-        </tr>
-        </tbody>
-      </table>
-
-      <h3>LT</h3>
-
-      <br>
-
-      <table class="timetable-table">
-        <thead>
-        <tr>
-          <th class="timetable-date col-xs-5">タイトル</th>
-          <th class="timetable-date col-xs-3">名前</th>
-          <th class="timetable-date col-xs-4">所属</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-          <td class="timetable-time">松江ではたらく</td>
-          <td class="timetable-time">加藤 龍</td>
-          <td class="timetable-time">株式会社Misoca</td>
-        </tr>
-        <tr>
-          <td class="timetable-time">僕たちとRuby</td>
-          <td class="timetable-time">ハー・タイン&ポール</td>
-          <td class="timetable-time">株式会社モンスター・ラボ</td>
-        </tr>
-        <tr>
-          <td class="timetable-time">未定</td>
-          <td class="timetable-time">竹田 喜世子</td>
-          <td class="timetable-time">株式会社日本ハイソフト</td>
-        </tr>
-        <tr>
-          <td class="timetable-time">未定</td>
-          <td class="timetable-time">前田 修吾</td>
-          <td class="timetable-time">株式会社ネットワーク応用通信研究所（NaCl）</td>
-        </tr>
-        </tbody>
-      </table>
-
-
-      <br>
       <h3>タイムテーブル</h3>
       <br>
       <h4>午前の部</h4>
@@ -356,7 +276,10 @@ publish: true
               </span>
             </td>
             <td class="timetable-time">
-              <span>橋本将 氏</span>
+              <span>
+                株式会社ネットワーク応用通信研究所（NaCl）<br />
+                橋本将 氏
+              </span>
             </td>
           </tr>
           <tr>
@@ -370,7 +293,10 @@ publish: true
               </span>
             </td>
             <td class="timetable-time">
-              <span>平岡瞬 氏</span>
+              <span>
+                ゲームリンクス<br />
+                平岡瞬 氏
+              </span>
             </td>
           </tr>
           <tr>
@@ -383,11 +309,57 @@ publish: true
               </span>
             </td>
             <td class="timetable-time">
+            </td>
+          </tr>
+          <tr>
+            <td class="timetable-time">
+            </td>
+            <td class="timetable-time">
+              <span>松江ではたらく</span>
+            </td>
+            <td class="timetable-time">
               <span>
-                加藤 龍<br>
-                ポール<br>
-                竹田 喜世子<br>
-                前田 修吾<br>
+                株式会社Misoca<br />
+                加藤龍 氏
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td class="timetable-time">
+            </td>
+            <td class="timetable-time">
+              <span>僕たちとRuby</span>
+            </td>
+            <td class="timetable-time">
+              <span>
+                株式会社モンスター・ラボ<br />
+                ハー・タイン 氏 & ポール 氏
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td class="timetable-time">
+            </td>
+            <td class="timetable-time">
+              <span>未定</span>
+            </td>
+            <td class="timetable-time">
+              <span>
+                株式会社日本ハイソフト<br />
+                竹田喜世子 氏
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <td class="timetable-time">
+            </td>
+            <td class="timetable-time">
+              <span>未定</span>
+            </td>
+            <td class="timetable-time">
+              <span>
+                株式会社ネットワーク応用通信研究所（NaCl）<br />
+                前田修吾 氏
               </span>
             </td>
           </tr>
@@ -402,7 +374,10 @@ publish: true
               </span>
             </td>
             <td class="timetable-time">
-              <span>石川瑞希 氏</span>
+              <span>
+                ファーエンドテクノロジー株式会社<br />
+                石川瑞希 氏
+              </span>
             </td>
           </tr>
           <tr>
@@ -416,7 +391,10 @@ publish: true
               </span>
             </td>
             <td class="timetable-time">
-              <span>日高克也 氏</span>
+              <span>
+                株式会社Misoca<br />
+                日高克也 氏
+              </span>
             </td>
           </tr>
           <tr>
@@ -430,7 +408,10 @@ publish: true
               </span>
             </td>
             <td class="timetable-time">
-              <span>東裕人 氏</span>
+              <span>
+                しまねソフト研究開発センター<br />
+                東裕人 氏
+              </span>
             </td>
           </tr>
           <tr>

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -212,7 +212,10 @@ publish: true
               </span>
             </td>
             <td class="timetable-time">
-              <span>井上浩 氏</span>
+              <span>
+                株式会社ネットワーク応用通信研究所（NaCl）<br />
+                井上浩 氏
+              </span>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
更新時の変更箇所を減らすため、松江Ruby会議09のスピーカーとLTをタイムテーブルに統合しました。