### PR TITLE
松江Ruby会議09の講演者ご紹介の修正と表示している会社名を合わせる修正

### DIFF
--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -148,10 +148,10 @@ publish: true
         <span class="person matz"></span>
         <div class="profile">
           <span class="name">まつもとゆきひろ 氏</span>
-                <span class="social">
-                  <a href="https://twitter.com/yukihiro_matz" class="twitter"></a>
-                  <a href="https://github.com/matz" class="github"></a>
-                </span>
+          <span class="social">
+            <a href="https://twitter.com/yukihiro_matz" class="twitter"></a>
+            <a href="https://github.com/matz" class="github"></a>
+          </span>
           <p class="description">
             我らがRubyの生みの親。小泉八雲氏と肩を並べて松江市名誉市民でもあり、Rubyを通して地方から世界のソフトウェア業界に多大な影響を与えています。今回も松江ならでは、基調講演でお話をしていただきます。
           </p>
@@ -161,9 +161,9 @@ publish: true
         <span class="person inoue"></span>
         <div class="profile">
           <span class="name">井上浩 氏</span>
-                <span class="social">
-                  <a href="https://twitter.com/nacl" class="twitter"></a>
-                </span>
+          <span class="social">
+            <a href="https://twitter.com/nacl" class="twitter"></a>
+          </span>
           <p class="description">
             株式会社ネットワーク応用通信研究所(NaCl) 代表取締役。会社設立当初から自由に使えるオープンソースソフトウェアを利用した事業を展開、座右の銘は「禍福は糾える縄のごとし」、及び「人生最後はチャラ」 ゲスト講演でお話いただきます。
           </p>

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -200,7 +200,7 @@ publish: true
         <li>
           <p>
             Google Home<br />
-            （株式会社ネットワーク応用通信研究所様　ご提供）<br />
+            （株式会社ネットワーク応用通信研究所（NaCl）様　ご提供）<br />
           </p>
         </li>
       </ul>
@@ -530,7 +530,7 @@ publish: true
         <li>
           <a href="http://www.netlab.jp/" target="_blank">
             <span class="item_img"><img alt="nacl" src="img/banner/nacl.jpg" class="nacl"></span>
-            <span class="item_title">株式会社ネットワーク応用通信研究所</span>
+            <span class="item_title">株式会社ネットワーク応用通信研究所（NaCl）</span>
           </a>
         </li>
         <li>

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -147,7 +147,7 @@ publish: true
       <div class="col-xs4 col-md-4">
         <span class="person matz"></span>
         <div class="profile">
-          <span class="name">まつもとゆきひろ氏</span>
+          <span class="name">まつもとゆきひろ 氏</span>
                 <span class="social">
                   <a href="https://twitter.com/yukihiro_matz" class="twitter"></a>
                   <a href="https://github.com/matz" class="github"></a>
@@ -160,7 +160,7 @@ publish: true
       <div class="col-xs4 col-md-4">
         <span class="person inoue"></span>
         <div class="profile">
-          <span class="name">井上浩</span>
+          <span class="name">井上浩 氏</span>
                 <span class="social">
                   <a href="https://twitter.com/nacl" class="twitter"></a>
                 </span>


### PR DESCRIPTION
松江Ruby会議09の講演者ご紹介の敬称を追加したのと、インデントがズレていたので修正しました。
あと会社名を合わせる修正をしました。