### PR TITLE
松江Ruby会議09のタイムテーブルをテンプレートファイル化する修正

### DIFF
--- a/Rules
+++ b/Rules
@@ -45,7 +45,7 @@ compile '/matrk0[5-9]/' do
   if item.binary?
     # don’t filter binary items
   else
-    filter :erb
+    filter :erb, trim_mode: '-'
     filter :kramdown
     layout 'matrk'
   end
@@ -87,4 +87,4 @@ route '*' do
   end
 end
 
-layout '*', :erb
+layout '*', :erb, trim_mode: '-'

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -214,270 +214,29 @@ publish: true
       <h3>タイムテーブル</h3>
       <br>
       <h4>午前の部</h4>
-      <table class="timetable-table">
-        <thead>
-          <th class="timetable-date col-xs-3">
-            <span class="inner">時間</span>
-          </th>
-          <th class="timetable-date col-xs-5">
-            <span class="inner">プログラム</span>
-          </th>
-          <th class="timetable-date col-xs-4">
-            <span class="inner">発表者</span>
-          </th>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="timetable-time">
-              <span>11:00 〜 11:05</span>
-            </td>
-            <td class="timetable-time">
-              <span>オープニング</span>
-            </td>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>11:10 〜 11:55</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                ゲスト講演<br />
-                「未定」
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                株式会社ネットワーク応用通信研究所（NaCl）<br />
-                井上浩 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>12:00 〜 13:30</span>
-            </td>
-            <td class="timetable-time">
-              <span>昼食休憩</span>
-            </td>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+<%= render('_time_table', tbody_data: [
+  ['11:00 〜 11:05', 'オープニング', ''],
+  ['11:10 〜 11:55', 'ゲスト講演<br />「未定」', '株式会社ネットワーク応用通信研究所（NaCl）<br />井上浩 氏'],
+  ['12:00 〜 13:30', '昼食休憩', '']
+]).gsub(/^/, '      ') -%>
 
       <h4>午後の部</h4>
-      <table class="timetable-table">
-        <thead>
-          <th class="timetable-date col-xs-3">
-            <span class="inner">時間</span>
-          </th>
-          <th class="timetable-date col-xs-5">
-            <span class="inner">プログラム</span>
-          </th>
-          <th class="timetable-date col-xs-4">
-            <span class="inner">発表者</span>
-          </th>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="timetable-time">
-              <span>13:30 〜 14:20</span>
-            </td>
-            <td class="timetable-time">
-              <span>基調講演</span>
-            </td>
-            <td class="timetable-time">
-              <span>まつもとゆきひろ 氏</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>14:20 〜 14:35</span>
-            </td>
-            <td class="timetable-time">
-              <span>休憩・写真撮影</span>
-            </td>
-            <td class="timetable-time">
-              <span> - </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>14:35 〜 14:50</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                session 1<br />
-                「RedmineサーバのおもりをするついでにRedmineで色々遊んでみた」
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                株式会社ネットワーク応用通信研究所（NaCl）<br />
-                橋本将 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>14:50 〜 15:05</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                session 2<br />
-                「僕とMastodon」
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                ゲームリンクス<br />
-                平岡瞬 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>15:15 〜 15:40</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                LTセッション
-              </span>
-            </td>
-            <td class="timetable-time">
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-            </td>
-            <td class="timetable-time">
-              <span>松江ではたらく</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                株式会社Misoca<br />
-                加藤龍 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-            </td>
-            <td class="timetable-time">
-              <span>僕たちとRuby</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                株式会社モンスター・ラボ<br />
-                ハー・タイン 氏 & ポール 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-            </td>
-            <td class="timetable-time">
-              <span>わたしとスプラウト.rb</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                株式会社日本ハイソフト<br />
-                竹田喜世子 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-            </td>
-            <td class="timetable-time">
-              <span>未定</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                株式会社ネットワーク応用通信研究所（NaCl）<br />
-                前田修吾 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>15:45 〜 16:00</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                session 3<br />
-                「若手エンジニア ＋ Rubyプロジェクト = ？？？」
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                ファーエンドテクノロジー株式会社<br />
-                石川瑞希 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>16:00 〜 16:15</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                session 4<br />
-                「後方互換の保ち方」
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                株式会社Misoca<br />
-                日高克也 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>16:15 〜 16:30</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                session 5<br />
-                「Yet Another Ruby Application Framework "Alone"」
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                ITOC しまねソフト研究開発センター<br />
-                東裕人 氏
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>16:35 〜 17:20</span>
-            </td>
-            <td class="timetable-time">
-              <span>Ruby Quiz</span>
-            </td>
-            <td class="timetable-time">
-              <span>-</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>17:20 〜 17:30</span>
-            </td>
-            <td class="timetable-time">
-              <span>クロージング</span>
-            </td>
-            <td class="timetable-time">
-              <span>-</span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+<%= render('_time_table', tbody_data: [
+  ['13:30 〜 14:20', '基調講演', 'まつもとゆきひろ 氏'],
+  ['14:20 〜 14:35', '休憩・写真撮影', ' - '],
+  ['14:35 〜 14:50', 'session 1<br />「RedmineサーバのおもりをするついでにRedmineで色々遊んでみた」', '株式会社ネットワーク応用通信研究所（NaCl）<br />橋本将 氏'],
+  ['14:50 〜 15:05', 'session 2<br />「僕とMastodon」', 'ゲームリンクス<br />平岡瞬 氏'],
+  ['15:15 〜 15:40', 'LTセッション', ''],
+  ['',               '松江ではたらく', '株式会社Misoca<br />加藤龍 氏'],
+  ['',               '僕たちとRuby', '株式会社モンスター・ラボ<br />ハー・タイン 氏 & ポール 氏'],
+  ['',               'わたしとスプラウト.rb', '株式会社日本ハイソフト<br />竹田喜世子 氏'],
+  ['',               '未定', '株式会社ネットワーク応用通信研究所（NaCl）<br />前田修吾 氏'],
+  ['15:45 〜 16:00', 'session 3<br />「若手エンジニア ＋ Rubyプロジェクト = ？？？」', 'ファーエンドテクノロジー株式会社<br />石川瑞希 氏'],
+  ['16:00 〜 16:15', 'session 4<br />「後方互換の保ち方」', '株式会社Misoca<br />日高克也 氏'],
+  ['16:15 〜 16:30', 'session 5<br />「Yet Another Ruby Application Framework "Alone"」', 'ITOC しまねソフト研究開発センター<br />東裕人 氏'],
+  ['16:35 〜 17:20', 'Ruby Quiz', '-'],
+  ['17:20 〜 17:30', 'クロージング', '-']
+]).gsub(/^/, '      ') -%>
     </div>
   </div>
 </div>

--- a/layouts/_time_table.html
+++ b/layouts/_time_table.html
@@ -1,0 +1,24 @@
+<table class="timetable-table">
+  <thead>
+    <th class="timetable-date col-xs-3">
+      <span class="inner">時間</span>
+    </th>
+    <th class="timetable-date col-xs-5">
+      <span class="inner">プログラム</span>
+    </th>
+    <th class="timetable-date col-xs-4">
+      <span class="inner">発表者</span>
+    </th>
+  </thead>
+  <tbody>
+    <%- @tbody_data.each do |row| -%>
+    <tr>
+      <%- row.each do |column| -%>
+      <td class="timetable-time">
+        <span><%= column -%></span>
+      </td>
+      <%- end -%>
+    </tr>
+    <%- end -%>
+  </tbody>
+</table>


### PR DESCRIPTION
`render` メソッドの呼出し時にテンプレートファイル内に `<% %>` や `<%= %>` があると `bundle exec nanoc compile` 時に空行が残るのでRulesに `trim_mode` を追加して `<%-  -%>` の指定ができるようにしました。

松江Ruby会議のタイムテーブルが縦に長いので、テンプレートファイルから生成するように変更しました。

ただ `render` でテンプレートファイルを呼出して生成したHTMLのインデントがズレるので `gsub` で空白スペースを前方に追加して調節しています。
`bundle exec nanoc compile` した後に生成される `public/matrk09/index.html` のインデントについては無視しても良いとのことでしたら `gsub` は削除して `render` の位置を変更します。

松江Ruby会議09のみ更新しています。過去の松江Ruby会議は別PRで対応します。