### PR TITLE
松江Ruby会議の受付終了したDoorkeeperのボタンを削除

### DIFF
--- a/content/matrk05/index.html
+++ b/content/matrk05/index.html
@@ -465,14 +465,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">参加登録の案内</h2>
       </blockquote>
-       <p class="main-text font-Fenix">カンファレンスの参加費は無料ですが人数把握のため事前登録をお願いします。</p>
-       <p class="main-text font-Fenix">その他昼食エントリ、懇親会についての詳細は下記のリンク（doorkeeper）を参照してください。 </p>
-      <a href="http://matsue-rb.doorkeeper.jp/events/8268">
-      <button class="button" type="button">参加受付</button></a>
-      <a href="http://matsue-rb.doorkeeper.jp/events/8278">
-      <button class="button" type="button">昼食エントリ</button></a>
-      <a href="http://matsue-rb.doorkeeper.jp/events/8277">
-      <button class="button" type="button">懇親会</button></a>
+      <p class="main-text font-Fenix">参加登録は受付終了しました。</p>
     </div>
   </div>
 </div>

--- a/content/matrk06/index.html
+++ b/content/matrk06/index.html
@@ -309,15 +309,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">参加登録の案内</h2>
       </blockquote>
-      <p class="main-text font-Fenix">カンファレンスの参加費は無料ですが人数把握のため事前登録をお願いします。</p>
-      <p class="main-text font-Fenix">講演後に懇親会を予定にしておりますので合わせて事前登録をお願いします。</p>
-      <p class="main-text font-Fenix">なお懇親会（学生）については人数に限りがありますのでお早めにエントリください！</p>
-      <a href="http://matsue-rb.doorkeeper.jp/events/16078" target="_blank">
-      <button class="button" type="button">参加受付</button></a>
-      <a href="http://matsue-rb.doorkeeper.jp/events/16079" target="_blank">
-      <button class="button" type="button">懇親会(一般)</button></a>
-      <a href="http://matsue-rb.doorkeeper.jp/events/16899" target="_blank">
-      <button class="button" type="button">懇親会(学生)</button></a>
+      <p class="main-text font-Fenix">参加登録は受付終了しました。</p>
     </div>
   </div>
 </div>

--- a/content/matrk07/index.html
+++ b/content/matrk07/index.html
@@ -370,15 +370,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">参加登録の案内</h2>
       </blockquote>
-      <p class="main-text font-Fenix">カンファレンスの参加費は無料ですが人数把握のため事前登録をお願いします。</p>
-      <p class="main-text font-Fenix">講演後に懇親会を予定にしておりますので合わせて事前登録をお願いします。</p>
-      <p class="main-text font-Fenix">なお懇親会（学生）については人数に限りがありますのでお早めにエントリください！</p>
-      <a href="http://matsue-rb.doorkeeper.jp/events/27629" target="_blank">
-      <button class="button" type="button">参加受付</button></a>
-      <a href="http://matsue-rb.doorkeeper.jp/events/27632" target="_blank">
-      <button class="button" type="button">懇親会(一般)</button></a>
-      <a href="http://matsue-rb.doorkeeper.jp/events/27631" target="_blank">
-      <button class="button" type="button">懇親会(学生)</button></a>
+      <p class="main-text font-Fenix">参加登録は受付終了しました。</p>
     </div>
   </div>
 </div>

--- a/content/matrk08/index.html
+++ b/content/matrk08/index.html
@@ -417,15 +417,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">参加登録の案内</h2>
       </blockquote>
-      <p class="main-text font-Fenix">カンファレンスの参加費は無料ですが人数把握のため事前登録をお願いします。</p>
-      <p class="main-text font-Fenix">講演後に懇親会を予定にしておりますので合わせて事前登録をお願いします。</p>
-      <p class="main-text font-Fenix">なお懇親会（学生）については人数に限りがありますのでお早めにエントリください！</p>
-      <a href="https://matsue-rb.doorkeeper.jp/events/52118" target="_blank">
-      <button class="button" type="button">参加受付</button></a>
-      <a href="https://matsue-rb.doorkeeper.jp/events/52119" target="_blank">
-      <button class="button" type="button">懇親会(一般)</button></a>
-      <a href="https://matsue-rb.doorkeeper.jp/events/54248" target="_blank">
-      <button class="button" type="button">懇親会(学生)</button></a>
+      <p class="main-text font-Fenix">参加登録は受付終了しました。</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
松江Ruby会議09と同じように既に受付終了しているので、松江Ruby会議の受付終了したDoorkeeperのボタンを削除しました。