### PR TITLE
松江Ruby会議05のタイムテーブルをテンプレートファイル化する修正

### DIFF
--- a/content/matrk05/index.html
+++ b/content/matrk05/index.html
@@ -155,109 +155,16 @@ publish: true
       <p class="main-text font-Fenix">参加希望の方は<a href="#register">昼食エントリの参加登録</a>をお願いします。</p>
       <br>
       <h4 class="font-Fenix" id="message">タイムテーブル</h4>
-      <table class="timetable-table">
-        <thead>
-          <th class="timetable-date">
-            <span class="inner">時間</span>
-          </th>
-          <th class="timetable-date">
-            <span class="inner">プログラム</span>
-          </th>
-          <th class="timetable-date">
-            <span class="inner">発表者</span>
-          </th>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="timetable-time">
-              <span>11:00</span>
-            </td>
-            <td class="timetable-time">
-              <span>開場</span>
-            </td>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>11:30 〜 13:00</span>
-            </td>
-            <td class="timetable-time">
-              <span>LT大会、昼食</span>
-            </td>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-            <td class="timetable-time">
-              <span>「とくちゃんと Ruby Association」</span>
-            </td>
-            <td class="timetable-time">
-              <span>徳永 翔二 氏</span>
-            </td>
-          </tr>
-           <tr>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-            <td class="timetable-time">
-              <span>「正しいモチベーションの上げ方」</span>
-            </td>
-            <td class="timetable-time">
-              <span>井上 裕之 氏（<a href="https://github.com/inoh">@inoh</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-            <td class="timetable-time">
-              <span>「Rubyと出会ってからの6年」</span>
-            </td>
-            <td class="timetable-time">
-              <span>高木 丈智 氏（<a href="https://github.com/takenory">@takenory</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-            <td class="timetable-time">
-              <span>「拡張ライブラリで作成するruby-assimp」</span>
-            </td>
-            <td class="timetable-time">
-              <span>佐田 明弘 氏（<a href="https://github.com/sada">@sada</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-            <td class="timetable-time">
-              <span>「基本設計」</span>
-            </td>
-            <td class="timetable-time">
-              <span>小谷 真一 氏（<a href="https://github.com/sn1128">@sn1128</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-            <td class="timetable-time">
-              <span>「Chef使うなら知っておくと便利なn個のCookbook」</span>
-            </td>
-            <td class="timetable-time">
-              <span>西田 雄也 氏（<a href="https://twitter.com/nishidayuya">@nishidayuya</a>）</span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+<%= render('_time_table', tbody_data: [
+  ['11:00',          '開場', ''],
+  ['11:30 〜 13:00', 'LT大会、昼食', ''],
+  ['',               '「とくちゃんと Ruby Association」', '徳永翔二 氏'],
+  ['',               '「正しいモチベーションの上げ方」', '井上裕之 氏（<a href="https://github.com/inoh">@inoh</a>）'],
+  ['',               '「Rubyと出会ってからの6年」', '高木丈智 氏（<a href="https://github.com/takenory">@takenory</a>）'],
+  ['',               '「拡張ライブラリで作成するruby-assimp」', '佐田明弘 氏（<a href="https://github.com/sada">@sada</a>）'],
+  ['',               '「基本設計」', '小谷真一 氏（<a href="https://github.com/sn1128">@sn1128</a>）'],
+  ['',               '「Chef使うなら知っておくと便利なn個のCookbook」', '西田雄也 氏（<a href="https://twitter.com/nishidayuya">@nishidayuya</a>）']
+]).gsub(/^/, '      ') -%>
       <br>
       <h3 class="font-Fenix" id="message">・午後の部</h3>
       <p class="main-text font-Fenix">松江Ruby会議の午後の部は<strong>まつもとゆきひろ氏</strong>による基調講演をはじめ、<strong>DXRuby開発者のmirichi氏</strong>のゲスト講演もあります。
@@ -267,129 +174,17 @@ publish: true
       <p class="main-text font-Fenix">参加希望の方は<a href="#register">参加登録</a>をお願いします。</p>
       <br>
       <h4 class="font-Fenix" id="message">タイムテーブル</h4>
-      <table class="timetable-table">
-        <thead>
-          <th class="timetable-date">
-            <span class="inner">時間</span>
-          </th>
-          <th class="timetable-date">
-            <span class="inner">プログラム</span>
-          </th>
-          <th class="timetable-date">
-            <span class="inner">発表者</span>
-          </th>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="timetable-time">
-              <span>13:00〜</span>
-            </td>
-            <td class="timetable-time">
-              <span>開場・受付開始</span>
-            </td>
-            <td class="timetable-time">
-              <span></span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>13:25 〜 13:30</span>
-            </td>
-            <td class="timetable-time">
-              <span>開会あいさつ</span>
-            </td>
-            <td class="timetable-time">
-              <span>主催者</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>13:30 〜 14:00</span>
-            </td>
-            <td class="timetable-time">
-              <span>基調講演</span>
-            </td>
-            <td class="timetable-time">
-              <span>まつもとゆきひろ 氏</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>14:10 〜 14:40</span>
-            </td>
-            <td class="timetable-time">
-              <span>ゲスト講演「DXRubyのご紹介」</span>
-            </td>
-            <td class="timetable-time">
-              <span><a href="http://twitter.com/mirichi">@mirichi</a> 氏<br>（DXRuby開発者）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>14:50 〜 15:20</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                「ちょっとるりまでも更新してみようか」（ライブコー...ドキュメンティング）<br>
-                普段Matsue.rb定例会で@sho-hがやっている事を紹介します。コーディングではないのはご愛嬌？
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>橋本 将 氏<br>（<a href="https://github.com/sho-h">@sho-h</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>15:30 〜 16:00</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                「RubyMotionいつやるの？」（ライブコーディング）<br>
-                 RubyMotionを使ったiOSアプリ開発を実演します！
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>木村 友哉 氏<br>（<a href="https://github.com/tomo-k">@tomo-k</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>16:10 〜 16:40</span>
-            </td>
-            <td class="timetable-time">
-              <span>「Module#prependとRefinementsで遊ぶ」（ライブコーディング）</span>
-            </td>
-            <td class="timetable-time">
-              <span>前田 修吾 氏<br>（<a href="https://github.com/shugo">@shugo</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>16:50 〜 17:20</span>
-            </td>
-            <td class="timetable-time">
-              <span>
-                「takaokouji とrockzeroのぶつかり稽古」（ライブコーディング）<br>
-                takaokouji氏が出題したtestを満たすコードをrockzero君が回答していきます！
-              </span>
-            </td>
-            <td class="timetable-time">
-              <span>高尾 宏治 氏<br>（<a href="https://github.com/takaokouji">@takaokouji</a>）<br>岩石 嶺 君<br>（<a href="https://github.com/rockzero">@rockzero</a>）</span>
-            </td>
-          </tr>
-          <tr>
-            <td class="timetable-time">
-              <span>17:30 〜</span>
-            </td>
-            <td class="timetable-time">
-              <span>閉会挨拶</span>
-            </td>
-            <td class="timetable-time">
-              <span>主催者</span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+<%= render('_time_table', tbody_data: [
+  ['13:00 〜',       '開場・受付開始', ''],
+  ['13:25 〜 13:30', '開会あいさつ', '主催者'],
+  ['13:30 〜 14:00', '基調講演', 'まつもとゆきひろ 氏'],
+  ['14:10 〜 14:40', 'ゲスト講演「DXRubyのご紹介」', '<a href="http://twitter.com/mirichi">@mirichi</a> 氏<br>（DXRuby開発者）'],
+  ['14:50 〜 15:20', '「ちょっとるりまでも更新してみようか」（ライブコー...ドキュメンティング）<br>普段Matsue.rb定例会で@sho-hがやっている事を紹介します。コーディングではないのはご愛嬌？', '橋本将 氏<br>（<a href="https://github.com/sho-h">@sho-h</a>）'],
+  ['15:30 〜 16:00', '「RubyMotionいつやるの？」（ライブコーディング）<br> RubyMotionを使ったiOSアプリ開発を実演します！', '木村友哉 氏<br>（<a href="https://github.com/tomo-k">@tomo-k</a>）'],
+  ['16:10 〜 16:40', '「Module#prependとRefinementsで遊ぶ」（ライブコーディング）', '前田修吾 氏<br>（<a href="https://github.com/shugo">@shugo</a>）'],
+  ['16:50 〜 17:20', '「takaokouji とrockzeroのぶつかり稽古」（ライブコーディング）<br>takaokouji氏が出題したtestを満たすコードをrockzero君が回答していきます！', '高尾宏治 氏<br>（<a href="https://github.com/takaokouji">@takaokouji</a>）<br>岩石嶺 君<br>（<a href="https://github.com/rockzero">@rockzero</a>）'],
+  ['17:30 〜',       '閉会挨拶', '主催者']
+]).gsub(/^/, '      ') -%>
       <br>
       <h3 class="font-Fenix" id="message">・夕方の部、懇親会 </h3>
       <br>


### PR DESCRIPTION
松江Ruby会議05のタイムテーブルをテンプレートファイル化する修正しました。
「夕方の部、懇親会」は過去の松江Ruby会議のタイムテーブルの中でここだけ異なる表示なので、テンプレートファイル化せずにそのままにしています。