### PR TITLE
スケジュールの松江Ruby会議08と09の情報を更新

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -60,7 +60,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 
 |イベント名                  |状態          |日時                   |会場                    |事前登録|料金|リンク                      |
 |----------------------------|--------------|-----------------------|------------------------|--------|----|----------------------------|
-| 松江Ruby会議08        | 参加受付中 | 2016/12/17 11:00-17:40| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議08", "/matrk08") %> |
+| 松江Ruby会議08        | 終了(91名参加) | 2016/12/17 11:00-17:40| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議08", "/matrk08") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0056/0056-MatsueRubyKaigi08Report.html")%><br /><%= link_to("Togetterまとめ", "https://togetter.com/li/1061092") %><br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPBU5f0cAn4BceCG48EGSHsA") %> |
 | Matsue.rb定例会H28.11(#79) | 終了(24名参加) | 2016/11/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(331157923889359) %> |
 | Matsue.rb定例会H28.10(#78) | 終了(33名参加) | 2016/10/15 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(615508341956073) %> |
 | Matsue.rb定例会H28.09(#77) | 終了(29名参加) | 2016/09/03 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(102458883520407) %> |

--- a/content/schedule.html
+++ b/content/schedule.html
@@ -21,7 +21,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 |----------------------------|--------------|-----------------------|------------------------|--------|----|----------------------------|
 | Matsue.rb定例会H30.08(#99) | 準備中 | 2018/08/18 13:30-17:00 | <%= link_to_terrsa %> 4F 研修室2 | 不要   |検討中| 準備中|
 | Matsue.rb定例会H30.07(#98) | 参加受付中 | 2018/07/21 13:30-17:00 | <%= link_to_terrsa %> 4F 研修室2 | 不要   |一般200円、学生無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 76528) %> |
-| 松江Ruby会議09             | 終了(50名参加) | 2018/06/30 11:00-17:40| <%= link_to_osslab %> | 必要   |無料| <%= link_to("松江Ruby会議09", "/matrk09") %> |
+| 松江Ruby会議09             | 終了(50名参加) | 2018/06/30 11:00-17:40| <%= link_to_osslab %> | 必要   |無料| <%= link_to("松江Ruby会議09", "/matrk09") %><br /><%= link_to("Togetterまとめ", "https://togetter.com/li/1243152") %> |
 | Matsue.rb定例会H30.06(#97) | 終了(27名参加) | 2018/06/23 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 75223) %> |
 | Matsue.rb定例会H30.05(#96) | 終了(23名参加) | 2018/05/26 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 73573) %> |
 | Matsue.rb定例会H30.04(#95) | 終了(19名参加) | 2018/04/21 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= link_to_doorkeeper('Doorkeeper', 'matsue-rb', 72428) %> |


### PR DESCRIPTION
スケジュールの松江Ruby会議08の情報が更新されてなかったので修正しました。
情報はるびまを参考にしました。

あと松江Ruby会議09のTogetterまとめのリンクを追加しました。