### PR TITLE
松江Ruby会議の参加登録に関するテキストを削除

### DIFF
--- a/content/matrk05/index.html
+++ b/content/matrk05/index.html
@@ -152,7 +152,6 @@ publish: true
       </blockquote>
       <h3 class="font-Fenix" id="message">・午前の部</h3>
       <p class="main-text font-Fenix">松江Ruby会議の開会前に交流を兼ねてLT大会を行います。</p>
-      <p class="main-text font-Fenix">参加希望の方は<a href="#register">昼食エントリの参加登録</a>をお願いします。</p>
       <br>
       <h4 class="font-Fenix" id="message">タイムテーブル</h4>
 <%= render('_time_table', tbody_data: [
@@ -171,7 +170,6 @@ publish: true
       </p>
       <p class="main-text font-Fenix">ライブコーディングではMatsue.rbのメンバーによる、日頃の活動の成果の発表に加え、Rubyコミッターも参加します！ </p>
       <br>
-      <p class="main-text font-Fenix">参加希望の方は<a href="#register">参加登録</a>をお願いします。</p>
       <br>
       <h4 class="font-Fenix" id="message">タイムテーブル</h4>
 <%= render('_time_table', tbody_data: [
@@ -245,7 +243,7 @@ publish: true
               <span>彩鮮酒楽　やぁ</span>
             </td>
             <td class="timetable-time">
-              <span>参加希望の方は 懇親会の参加登録 をお願いします。</span>
+              <span></span>
             </td>
           </tr>
         </tbody>

--- a/content/matrk06/index.html
+++ b/content/matrk06/index.html
@@ -150,7 +150,6 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">プログラム</h2>
       </blockquote>
-      <p class="main-text font-Fenix">参加希望の方は<a href="#register">参加登録</a>をお願いします。</p>
       <h3 class="font-Fenix" id="message">タイムテーブル</h3>
 <%= render('_time_table', tbody_data: [
   ['13:00〜',        '開場・受付開始', ''],

--- a/content/matrk07/index.html
+++ b/content/matrk07/index.html
@@ -145,7 +145,6 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">プログラム</h2>
       </blockquote>
-      <p class="main-text font-Fenix">参加希望の方は<a href="#register">参加登録</a>をお願いします。</p>
       <h3>プログラミングコンテスト</h3>
       <p>
         開催当日はコーディング転職サービスpaizaを使用しプログラミングコンテストを行います。<br>

--- a/content/matrk08/index.html
+++ b/content/matrk08/index.html
@@ -194,9 +194,6 @@ publish: true
           </div>
       </div>
       <hr>
-      <div class="row">
-        <p class="main-text font-Fenix" style="margin-left: 20px">参加希望の方は<a href="#register">参加登録</a>をお願いします。</p>
-      </div>
       <h3>プログラミングコンテスト</h3>
       <p>
         プログラミングコンテストは11/24〜12/14が応募期間でした。<br>


### PR DESCRIPTION
過去の松江Ruby会議で受付終了しているのに参加登録を促すテキストがあるので削除しました。