### PR TITLE
開催終了した松江Ruby会議のお問い合わせのテキストを変更

### DIFF
--- a/content/matrk05/index.html
+++ b/content/matrk05/index.html
@@ -273,9 +273,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">お問い合わせ</h2>
       </blockquote>
-      <p class="main-text font-Fenix">松江Ruby会議05の全日程は終了いたしました。</p>
-      <p class="main-text font-Fenix">お問い合わせについては終了しております。</p>
-      <p class="main-text font-Fenix">たくさんの方にご参加いただきありがとうございました。</p>
+      <p class="main-text font-Fenix">松江Ruby会議05は開催終了しました。お問い合わせの受付も終了しております。ご参加ありがとうございました。</p>
     </div>
   </div>
   <div class="row">

--- a/content/matrk06/index.html
+++ b/content/matrk06/index.html
@@ -244,7 +244,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">お問い合わせ</h2>
       </blockquote>
-      <p class="main-text font-Fenix">松江Ruby会議06に関するお問い合わせは、matsuerubykaigi06 _at_ googlegroups.comまでメールにてご連絡ください。</p>
+      <p class="main-text font-Fenix">松江Ruby会議06は開催終了しました。お問い合わせの受付も終了しております。ご参加ありがとうございました。</p>
     </div>
   </div>
   <div class="row">

--- a/content/matrk07/index.html
+++ b/content/matrk07/index.html
@@ -371,7 +371,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">お問い合わせ</h2>
       </blockquote>
-      <p class="main-text font-Fenix">松江Ruby会議07に関するお問い合わせは、matsuerubykaigi07 _at_ googlegroups.comまでメールにてご連絡ください。</p>
+      <p class="main-text font-Fenix">松江Ruby会議07は開催終了しました。お問い合わせの受付も終了しております。ご参加ありがとうございました。</p>
     </div>
   </div>
   <div class="row">

--- a/content/matrk08/index.html
+++ b/content/matrk08/index.html
@@ -446,7 +446,7 @@ publish: true
         <blockquote>
           <h2 class="font-Fenix" id="message">お問い合わせ</h2>
         </blockquote>
-        <p class="main-text font-Fenix">松江Ruby会議08に関するお問い合わせは、matsuerubykaigi _at_ googlegroups.comまでメールにてご連絡ください。</p>
+        <p class="main-text font-Fenix">松江Ruby会議08は開催終了しました。お問い合わせの受付も終了しております。ご参加ありがとうございました。</p>
       </div>
     </div>
     <div class="row">

--- a/content/matrk09/index.html
+++ b/content/matrk09/index.html
@@ -320,7 +320,7 @@ publish: true
       <blockquote>
         <h2 class="font-Fenix" id="message">お問い合わせ</h2>
       </blockquote>
-      <p class="main-text font-Fenix">松江Ruby会議09に関するお問い合わせは、matsuerubykaigi _at_ googlegroups.comまでメールにてご連絡ください。</p>
+      <p class="main-text font-Fenix">松江Ruby会議09は開催終了しました。お問い合わせの受付も終了しております。ご参加ありがとうございました。</p>
     </div>
   </div>
 </div><!-- /.container -->


### PR DESCRIPTION
開催終了した松江Ruby会議のお問い合わせのテキストを変更しました。
松江Ruby会議05がお問い合わせの受付終了のテキストになっているのと `matsuerubykaigi06 _at_ googlegroups.com` のような番号が付いているメールアドレスは既に使用していないため、メールが送信されないようにテキストを変更しました。