### PR TITLE
スケジュールの松江Ruby会議07に写真のリンクを追加

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -105,28 +105,9 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 
 <div markdown="1" class="table_schedule" >
 
-<%
-
-photos = {
-  "1" => "https://www.flickr.com/groups/2875305@N22/pool/",
-  "2" => "https://www.flickr.com/groups/2860565@N21/pool/",
-  "3" => "https://www.flickr.com/groups/2819938@N24/pool/",
-  "4" => "https://www.flickr.com/groups/2813862@N25/pool/",
-  "5" => "https://www.flickr.com/groups/2863519@N23/pool/",
-  "6" => "https://www.flickr.com/groups/2886121@N22/pool/",
-  "7" => "https://www.flickr.com/groups/2823956@N23/pool/",
-  "8" => "https://www.flickr.com/groups/2849741@N23/pool/",
-  "9" => "https://www.flickr.com/groups/2886131@N22/pool/",
-}
-
-def create_links(h)
-  h.collect { |s, url| link_to(s, url, target: "_blank") }.join(" ")
-end
-%>
-
 |イベント名                |状態          |日時                   |会場                    |事前登録|料金|リンク                      |
 |--------------------------|--------------|-----------------------|------------------------|--------|----|----------------------------|
-| 松江Ruby会議06           |終了(57名参加)| 2014/12/20 13:00-17:45| <%= link_to_osslab %>  | 必要   |無料| <%= link_to("松江Ruby会議06", "/matrk06") %><br/><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0051/0051-MatsueRubyKaigi06Report.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/760234") %><br />Flickr(<%= create_links(photos) %>)<br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPDCF_KeFc-U5W4XdmTYWPVd") %> |
+| 松江Ruby会議06           |終了(57名参加)| 2014/12/20 13:00-17:45| <%= link_to_osslab %>  | 必要   |無料| <%= link_to("松江Ruby会議06", "/matrk06") %><br/><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0051/0051-MatsueRubyKaigi06Report.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/760234") %><br />Flickr(<%= create_links(::PHOTO_PATHS[:matrk6]) %>)<br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPDCF_KeFc-U5W4XdmTYWPVd") %> |
 | Matsue.rb定例会H26.11(#57)<br/>(<%= link_to_sproutrb(event_id: 17153) %>,<br/><%= link_to_dojo(event_id: 16083) %>と同時開催) |終了(27名参加)| 2014/11/15 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(1452701574977672) %> |
 | Matsue.rb定例会H26.10(#56)<br/>(<%= link_to_sproutrb(event_id: 16353) %>,<br/><%= link_to_dojo(event_id: 15973) %>と同時開催) |終了(21名参加)| 2014/10/25 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(778993778798159) %> |
 | Matsue.rb定例会H26.09(#55)<br/>(<%= link_to_sproutrb(event_id: 15390) %> と同時開催)    |終了(18名参加)| 2014/09/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(732882966770439) %> |

--- a/content/schedule.html
+++ b/content/schedule.html
@@ -87,7 +87,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H27.12(#68) | 終了(21名参加) | 2015/12/26 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1002152419848347) %> |
 | Matsue.rb定例会H27.11(#67) | 終了(20名参加) | 2015/11/28 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1636150683321966) %> |
 | Matsue.rb定例会H27.10(#66) | 終了(27名参加) | 2015/10/24 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1723821987841280) %> |
-| 松江Ruby会議07        | 終了(66名参加) | 2015/09/26 11:00-17:10| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議07", "/matrk07") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0052/0052-MatsueRubyKaigi07Report.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/895041") %><br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPBSYjO2enmqSTpucHuHiA9S") %> |
+| 松江Ruby会議07        | 終了(66名参加) | 2015/09/26 11:00-17:10| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議07", "/matrk07") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0052/0052-MatsueRubyKaigi07Report.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/895041") %><br />Flickr(<%= create_links(::PHOTO_PATHS[:matrk7]) %>)<br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPBSYjO2enmqSTpucHuHiA9S") %> |
 | Matsue.rb定例会H27.08(#65) | 終了(24名参加) | 2015/08/29 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(109595892707985) %> |
 | Matsue.rb定例会H27.07(#64) | 終了(25名参加) | 2015/07/25 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(1499240573634239) %> |
 | Matsue.rb定例会H27.06(#63) | 終了(26名参加) | 2015/06/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(342643939277249) %> |

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -10,6 +10,20 @@ MEMBER_DEFAULTS = {
   website: ""
 }
 
+PHOTO_PATHS = {
+  matrk6: {
+    "1" => "https://www.flickr.com/groups/2875305@N22/pool/",
+    "2" => "https://www.flickr.com/groups/2860565@N21/pool/",
+    "3" => "https://www.flickr.com/groups/2819938@N24/pool/",
+    "4" => "https://www.flickr.com/groups/2813862@N25/pool/",
+    "5" => "https://www.flickr.com/groups/2863519@N23/pool/",
+    "6" => "https://www.flickr.com/groups/2886121@N22/pool/",
+    "7" => "https://www.flickr.com/groups/2823956@N23/pool/",
+    "8" => "https://www.flickr.com/groups/2849741@N23/pool/",
+    "9" => "https://www.flickr.com/groups/2886131@N22/pool/",
+  }
+}
+
 def get_tags(items)
   tag_num_hash = Hash.new(0)
   items.each do |item|
@@ -186,4 +200,8 @@ def generate_calendar
     end
   end
   cal.to_ical
+end
+
+def create_links(h)
+  h.collect { |s, url| link_to(s, url, target: "_blank") }.join(" ")
 end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -21,6 +21,9 @@ PHOTO_PATHS = {
     "7" => "https://www.flickr.com/groups/2823956@N23/pool/",
     "8" => "https://www.flickr.com/groups/2849741@N23/pool/",
     "9" => "https://www.flickr.com/groups/2886131@N22/pool/",
+  },
+  matrk7: {
+    "写真一覧" => "https://www.flickr.com/groups/2901550@N22/pool/",
   }
 }
 


### PR DESCRIPTION
スケジュールの松江Ruby会議07に写真のリンクを追加しました。
あと `content/schedule.html` で定義していた `create_links` メソッドを `lib/helper.rb` に定義位置を変更しました。