### PR TITLE
スケジュールの松江Ruby会議08に写真のリンクを追加

### DIFF
--- a/content/schedule.html
+++ b/content/schedule.html
@@ -60,7 +60,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 
 |イベント名                  |状態          |日時                   |会場                    |事前登録|料金|リンク                      |
 |----------------------------|--------------|-----------------------|------------------------|--------|----|----------------------------|
-| 松江Ruby会議08        | 終了(91名参加) | 2016/12/17 11:00-17:40| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議08", "/matrk08") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0056/0056-MatsueRubyKaigi08Report.html")%><br /><%= link_to("Togetterまとめ", "https://togetter.com/li/1061092") %><br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPBU5f0cAn4BceCG48EGSHsA") %> |
+| 松江Ruby会議08        | 終了(91名参加) | 2016/12/17 11:00-17:40| <%= link_to_terrsa %> 4F 大会議室 | 必要   |無料| <%= link_to("松江Ruby会議08", "/matrk08") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0056/0056-MatsueRubyKaigi08Report.html")%><br /><%= link_to("Togetterまとめ", "https://togetter.com/li/1061092") %><br />Flickr(<%= create_links(::PHOTO_PATHS[:matrk8]) %>)<br /><%= link_to("YouTube", "https://www.youtube.com/playlist?list=PLbJxhePIoIPBU5f0cAn4BceCG48EGSHsA") %> |
 | Matsue.rb定例会H28.11(#79) | 終了(24名参加) | 2016/11/27 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(331157923889359) %> |
 | Matsue.rb定例会H28.10(#78) | 終了(33名参加) | 2016/10/15 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(615508341956073) %> |
 | Matsue.rb定例会H28.09(#77) | 終了(29名参加) | 2016/09/03 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料| <%= fbe(102458883520407) %> |

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -24,6 +24,9 @@ PHOTO_PATHS = {
   },
   matrk7: {
     "写真一覧" => "https://www.flickr.com/groups/2901550@N22/pool/",
+  },
+  matrk8: {
+    "写真一覧" => "https://www.flickr.com/groups/4529348@N23/pool/",
   }
 }
 


### PR DESCRIPTION
スケジュールの松江Ruby会議08に写真のリンクを追加しました。