### PR TITLE
jQueryのバージョン更新後にコードを移行していなかったのに対応

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -43,7 +43,6 @@
 <div id="copyright">Copyright © <%= copyright_year %> <a href="https://www.facebook.com/groups/matsuerb">Matsue.rb(松江Ruby) </a>. All Rights Reserved. <span><%= link_to("GitHub・matsuerb/matsuerb-nanoc", "https://github.com/matsuerb/matsuerb-nanoc", {:target => "_blank"}) %></span></div>
 
 <script src="/js/grid/jquery-3.3.1.min.js"></script>
-<script src="https://code.jquery.com/jquery-migrate-3.0.1.js"></script>
 <script src="/js/grid/awesome-grid.js"></script>
 <script src="/js/grid/columnset.js"></script>
 

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -43,6 +43,7 @@
 <div id="copyright">Copyright © <%= copyright_year %> <a href="https://www.facebook.com/groups/matsuerb">Matsue.rb(松江Ruby) </a>. All Rights Reserved. <span><%= link_to("GitHub・matsuerb/matsuerb-nanoc", "https://github.com/matsuerb/matsuerb-nanoc", {:target => "_blank"}) %></span></div>
 
 <script src="/js/grid/jquery-3.3.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-migrate-3.0.1.js"></script>
 <script src="/js/grid/awesome-grid.js"></script>
 <script src="/js/grid/columnset.js"></script>
 

--- a/static/js/grid/columnset.js
+++ b/static/js/grid/columnset.js
@@ -19,7 +19,7 @@ new AwesomeGrid('ul.menu', {desktop: 601}).gutters(0).grid(1).desktop(8, 0);
 new AwesomeGrid('ul.column', {desktop: 601}).gutters(0).grid(1).desktop(3, 0);
 new AwesomeGrid('ul.grid', {desktop: 601}).gutters(0).grid(5).desktop(6, 0);
 
-$(window).load(function(){
+$(window).on('load', function(){
   new AwesomeGrid('ul.menu', {desktop: 601}).gutters(0).grid(1).desktop(8, 0);
   new AwesomeGrid('ul.grid', {desktop: 601}).gutters(0).grid(5).desktop(6, 0);
 });

--- a/static/js/grid/columnset.js
+++ b/static/js/grid/columnset.js
@@ -25,7 +25,7 @@ $(window).on('load', function(){
 });
 
 var timer = false;
-$(window).resize(function() {
+$(window).on('resize', function() {
   if( window.matchMedia('(max-width:600px)').matches ) {
     new AwesomeGrid('ul.grid', {desktop: 601}).gutters(0).grid(5).desktop(6, 0);
   } else {

--- a/static/matrk_common/js/application.js
+++ b/static/matrk_common/js/application.js
@@ -1,7 +1,7 @@
 $(function() {
 
   //ページ内スクロール
-  $(".menu a").click(function () {
+  $(".menu a").on("click", function () {
     var mark = $(".mark").offset().top;
     var id = $(this).attr("href");
     var point = 120;


### PR DESCRIPTION
#415 と #488 でコードまで移行していなかったのを修正。
matrkのapplication.jsでは `$('#')` する記述が残っているが例外を期待した動作に置き換えているので問題ない。そのため、.offsetが不正に呼ばれる事もない。