### PR TITLE
bundle exec nanoc compileの実行時の記事のソートの追加やcalendar.ics作成時の改行の設定を変更

### DIFF
--- a/content/sitemap.html
+++ b/content/sitemap.html
@@ -1,4 +1,4 @@
 ---
 title: "Matsue.rb"
 ---
-<%= xml_sitemap :items => @items.reject{ |i| i.binary? } %>
+<%= xml_sitemap :items => @items.sort_by { |i| i.identifier }.reject{ |i| i.binary? } %>

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -13,3 +13,6 @@ module Nanoc::Helpers::Tagging
     %[<a href="#{h base_url}#{h tag}/" rel="tag">#{h tag}</a>]
   end
 end
+
+# calendar.icsの作成時に75文字で改行されてGoogle Calendarにインポートできなくなるので追加
+Icalendar::MAX_LINE_LENGTH = 200

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -183,7 +183,7 @@ def generate_calendar
     end
   end
 
-  articles.each do |item|
+  articles.sort_by { |a| a.identifier }.each do |item|
     # :calendarの内容は考慮していないので注意
     if item[:calendar] != nil
       calendar = item[:calendar]


### PR DESCRIPTION
`bundle exec nanoc compile` の実行時に記事の並び順がバラバラになり、 `matsuerb.github.io` にコピー時に前回との順番が変わって差分が発生するのでソートするように変更しました。

icalendarのgemパッケージにある `Icalendar::MAX_LINE_LENGTH` 定数が75文字で改行するようになっており、その影響でcalendar.icsの作成時に改行されて、Google Calendarに正常にインポートできなくなったので、影響がない200文字で改行するように定数に再代入しています。
RFC 2445 Section 4.1の以下で決められているようです。

>   When parsing a content line, folded lines MUST first be unfolded
>   according to the unfolding procedure described above. When generating
 >  a content line, lines longer than 75 octets SHOULD be folded
 >  according to the folding procedure described above.

https://tools.ietf.org/html/rfc2445#section-4.1

ひとまず設定変更したのを入れて、それから75文字で改行されてもインポートできるのを対応しようと思います。