### PR TITLE
gemパッケージの更新に伴い、Icalendarが見つからないので読み込みを追加

### DIFF
--- a/lib/default.rb
+++ b/lib/default.rb
@@ -14,5 +14,6 @@ module Nanoc::Helpers::Tagging
   end
 end
 
+require 'icalendar'
 # calendar.icsの作成時に75文字で改行されてGoogle Calendarにインポートできなくなるので追加
 Icalendar::MAX_LINE_LENGTH = 200


### PR DESCRIPTION
gemパッケージが更新されて `lib/default.rb` が読み込まれる前に `icalendar` が読み込まれていないためにエラーが発生するので修正しました。