### PR TITLE
Nanoc 4系のアップグレードの対応

### DIFF
--- a/Rules
+++ b/Rules
@@ -71,14 +71,14 @@ compile '*' do
 end
 
 route '/static/*' do
-  item.identifier[7..-2]
+  item.identifier.to_s[7..-1]
 end
 
 route '/sitemap/' do
   '/sitemap.xml'
 end
 
-route '/feed/' do 
+route '/feed/' do
   '/feed.xml'
 end
 
@@ -89,10 +89,10 @@ end
 route '*' do
   if item.binary?
     # Write item with identifier /foo/ to /foo.ext
-    item.identifier.chop + '.' + item[:extension]
+    item.identifier.to_s.chop + '.' + item[:extension]
   else
     # Write item with identifier /foo/ to /foo/index.html
-    item.identifier + 'index.html'
+    item.identifier.to_s + 'index.html'
   end
 end
 

--- a/layouts/_head.html
+++ b/layouts/_head.html
@@ -1,6 +1,6 @@
 <meta charset="UTF-8" />
 <link rel="stylesheet" href="/css/siteindex.css" />
-<% if @item.identifier.size != 1 %>
+<% if @item.identifier.to_s.size != 1 %>
 <link rel="stylesheet" href="/css/sitecontents.css" />
 <% end %>
 <link rel="shortcut icon" href="/images/bn/favicon.ico" />

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -6,7 +6,7 @@
 <body>
 
 <ul class="menu">
-<% if @item.identifier.size == 1 %>
+<% if @item.identifier.to_s.size == 1 %>
 <li data-ag-x="3"><h1><img src="/images/bn/matsuerb_layer.png" alt="*"/><a href="/"><img src="/images/bn/matsuerb.png" alt="matsue.rb 松江Ruby"/></a></h1></li>
 <% else %>
 <li data-ag-x="3"><img src="/images/bn/matsuerb_layer.png" alt="*"/><a href="/"><img src="/images/bn/matsuerb.png" alt="matsue.rb 松江Ruby"/></a></li>

--- a/layouts/matrk.html
+++ b/layouts/matrk.html
@@ -12,7 +12,7 @@
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>" />
     <link rel="stylesheet" href="/matrk_common/css/bootstrap.css">
     <link rel="stylesheet" href="/matrk_common/css/carousel.css">
-    <link rel="stylesheet" href="<%= @item.identifier[/\/\w*\//] %>css/application.css">
+    <link rel="stylesheet" href="<%= @item.identifier.to_s[/\/\w*\//] %>css/application.css">
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script type="text/javascript" src="/matrk_common/js/application.js"></script>
   </head>

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -72,7 +72,7 @@ def tag_page_item_list(tag)
 #  html_source = '<dl">'
   html_source = ""
   items_with_tag(tag).each do |item|
-    html_source << "<blockquote><small>#{link_to(item[:title], item.identifier)}</small><p>#{strip_html(item.reps.first.compiled_content).slice(0,100)}...</p></blockquote>"
+    html_source << "<blockquote><small>#{link_to(item[:title], item.identifier.to_s)}</small><p>#{strip_html(item.reps.first.compiled_content).slice(0,100)}...</p></blockquote>"
   end
   html_source
 end
@@ -82,7 +82,7 @@ def article_list
   sorted_articles.each do |item|
     date = item[:updated_at]
     date ||= item[:created_at]
-    html_source << "<li>#{link_to(item[:title], item.identifier)} - #{date}</li>"
+    html_source << "<li>#{link_to(item[:title], item.identifier.to_s)} - #{date}</li>"
   end
   html_source << "</ul>"
 end
@@ -183,7 +183,7 @@ def generate_calendar
     end
   end
 
-  articles.sort_by { |a| a.identifier }.each do |item|
+  articles.sort_by { |a| a.identifier.to_s }.each do |item|
     # :calendarの内容は考慮していないので注意
     if item[:calendar] != nil
       calendar = item[:calendar]

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -63,7 +63,7 @@ def tag_page
   tags.each do |k, v|
     page_stats = {:title => "tag: #{k}", :tag_page_title => "#{k}"}
     option = {:binary => false}
-    @items << Nanoc::Item.new("<%= render('_tag') %>", page_stats, "/tags/#{k}/", option)
+    @items.create("<%= render('_tag') %>", page_stats, Nanoc::Identifier.new("/tags/#{k}/", type: :legacy), option)
   end
 end
 

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -39,6 +39,7 @@ data_sources:
     # The type is the identifier of the data source. By default, this will be
     # `filesystem_unified`.
     type: filesystem
+    identifier_type: legacy
 
     # The path where items should be mounted (comparable to mount points in
     # Unix-like systems). This is “/” by default, meaning that items will have
@@ -59,8 +60,10 @@ data_sources:
     # it will become “/about.html/” instead.
     allow_periods_in_identifiers: false
   -
-    type: static
+    type: filesystem
     items_root: /static/
+    content_dir: static
+    layouts_dir: null
 
 # Configuration for the “watch” command, which watches a site for changes and
 # recompiles if necessary.

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -33,6 +33,7 @@ prune:
 # hashes; each array element represents a single data source. By default,
 # there is only a single data source that reads data from the “content/” and
 # “layout/” directories in the site directory.
+string_pattern_type: legacy
 data_sources:
   -
     # The type is the identifier of the data source. By default, this will be

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -37,7 +37,7 @@ data_sources:
   -
     # The type is the identifier of the data source. By default, this will be
     # `filesystem_unified`.
-    type: filesystem_unified
+    type: filesystem
 
     # The path where items should be mounted (comparable to mount points in
     # Unix-like systems). This is “/” by default, meaning that items will have


### PR DESCRIPTION
Nanoc 4系のアップグレードの対応です。
[Nanoc 4 upgrade guide](https://nanoc.ws/doc/nanoc-4-upgrade-guide/)を参考にしました。

`bundle exec nanoc compile` してGitHub Pages用のリポジトリにコピーして、修正の差分が特に影響なさそうなのは確認しました。

修正の差分の多くが `nanoc 4.11.14` の情報の修正ですが `feed.xml`  のidタグの指定のところの日付が1日ズレてしまいます。
これは後ほど調査を進めようと思います。今のところ、公開日と更新日がその1日前の日付になっているからではと考えています。

## 実施した項目

* Quick upgrade guide
   * 1.Change mentions of Nanoc3 to Nanoc.
      * GitHubからのPRをマージしてNanoc 4系を使用するように変更。
   * 3.Add identifier_type: legacy to the individual data source configurations. For example:
      * nanoc.yamlに追加。
    * 4.Add string_pattern_type: legacy to the configuration file. For example:   
       * nanoc.yamlに追加。
    * 6.In the preprocess block, use @items.create rather than instantiating Nanoc::Item. For example:
       * `lib/helper.rb` の `tag_page` メソッド中の置換。
    * 8.In data sources, replace the identifier argument in calls to #new_item and #new_layout with an explicit Nanoc::Identifier instance, constructed with type: legacy:
       * `lib/helper.rb` の `tag_page` メソッド中の置換で `Nanoc::Identifier` を使用。 `/tags/#{k}/` の文字列をそのまま指定すると末尾に `/` が許可しないエラーが発生するため。
    * 11.If you use the static data source, disable it for now and follow the extended upgrade instructions below.
       * nanoc.yamlにstaticを指定していたので対応。
* Upgrading from the static data source
    * nanoc.yamlのstaticの指定を参考。
* Troubleshooting
    * `identifier` メソッドが文字列ではなく `Nanoc::Identifier` のインスタンスを返すようになったので `to_s` を使用するように変更。このサンプルのように `[7..-2]` の箇所があったが、拡張子の末尾が削れてしまうので `[7..-1]` にした。

## 今回は実施していない項目
* Quick upgrade guide
   * 2.Change mentions of @site.config to @config.
   * 5.In Rules, remove the rep. prefix from filter, layout, and snapshot. For example:
   * 7.In data sources, use #new_item or #new_layout rather than instantiating Nanoc::Item or Nanoc::Layout. For example:
   * 9.Replace .reps[0] by .reps[:default]. For example:
   * 10.Replace calls to #rep_named by reps[something], where something is the argument to #rep_named. For example:
* Enabling glob patterns
    * 1.Set string_pattern_type to glob in the configuration file. For example:
    * 2.Ensure that all string patterns in the Rules file, as well as in calls to @items[…], @layouts[…], and #render throughout the site, start and end with a slash. This is an intermediate step. For example:
   * 3.Replace * and + with **/* in all string patterns in the Rules file, as well as in calls to @items[…], @layouts[…], and #render throughout the site. For example:
* Enabling identifiers with extensions
    * 1.Set identifier_type to full in the configuration file. For example:
    * 2.Remove the trailing slash from any argument to #compile, #route, and #layout in the Rules file, as well as in calls to @items[…], @layouts[…], and #render throughout the site. If the pattern does not end with a “*”, add “.*”. For example:
    * 3.Update the routing rules to output the correct path. For example:
    * 4.Create a routing rule that matches index files in the content directory (such as content/index.md or content/blog/index.md). For example, put the following before any rules matching /**/*:
    * 5.If the site has calls to #children, ensure the lib/helpers.rb file contains use_helper Nanoc::Helpers::ChildParent, and replace method calls to #children with a function call to #children_of, passing in the item as an argument. For example:
    * 6.If the site has calls to #parent, ensure the lib/helpers.rb file contains use_helper Nanoc::Helpers::ChildParent, and replace method calls to #parent with a function call to #parent_of, passing in the item as an argument. For example:
* Removed features