### PR TITLE
Nanoc 4 upgrade guideのTroubleshootingに従い identifier.to_s に変更

### DIFF
--- a/layouts/nxt_matrk.html
+++ b/layouts/nxt_matrk.html
@@ -11,7 +11,7 @@
     <meta property="og:description" content="<%= @item[:title] %> <%= @item[:date] %> <%= @item[:location] %>にて開催">
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>" />
     <link rel="stylesheet" href="/matrk_common/css/normalize.css">
-    <link rel="stylesheet" href="<%= @item.identifier[/\/\w*\//] %>css/application.css">
+    <link rel="stylesheet" href="<%= @item.identifier.to_s[/\/\w*\//] %>css/application.css">
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,700&display=swap" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
レイアウトの `identifier` メソッドが返す値が Nanoc 4系になった時に変更されたことによる影響でした。
`to_s` メソッドを呼び出すように変更したのはNanoc 4 upgrade guideに従っています。

https://nanoc.ws/doc/nanoc-4-upgrade-guide/
