### PR TITLE
松江Ruby会議10のmetaを修正

### DIFF
--- a/layouts/nxt_matrk.html
+++ b/layouts/nxt_matrk.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><%= @item[:title] %></title>
-    <meta name="description" content="<%= @item[:title] %> <%= @item[:date] %> <%= @item[:location] %>">
+    <meta name="description" content="<%= @item[:title] %> Coming Soon...">
     <meta property="og:title" content="<%= @item[:title] %>">
     <meta property="og:type" content="website">
     <meta property="og:url" content="http://matsue.rubyist.net/">
-    <meta property="og:description" content="<%= @item[:title] %> <%= @item[:date] %> <%= @item[:location] %>にて開催">
+    <meta property="og:description" content="<%= @item[:title] %> Coming Soon...">
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>" />
     <link rel="stylesheet" href="/matrk_common/css/normalize.css">
     <link rel="stylesheet" href="<%= @item.identifier.to_s[/\/\w*\//] %>css/application.css">


### PR DESCRIPTION
## 概要
meta に開催予定が出てしまっていたので、一旦削除。