### PR TITLE
Ustreamのリンクを削除

### DIFF
--- a/content/matrk05/index.html
+++ b/content/matrk05/index.html
@@ -84,7 +84,7 @@ publish: true
         <tr>
           <th>中継</th>
           <td>午前の部: 中継は行いませんが録画はします
-          <br>午後の部: <a href="http://www.ustream.tv/channel/matsuerubykaigi05">動画による中継(USTREAM)</a>
+          <br>午後の部: 動画による中継
           </td>
         </tr>
         <tr>

--- a/content/matrk06/index.html
+++ b/content/matrk06/index.html
@@ -83,7 +83,7 @@ publish: true
         </tr>
         <tr>
           <th>中継</th>
-          <td><a href="http://www.ustream.tv/channel/matsuerubykaigi06">動画による中継(USTREAM)</a>
+          <td>動画による中継
           </td>
         </tr>
         <tr>

--- a/content/schedule.html
+++ b/content/schedule.html
@@ -159,7 +159,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H26.06(#52)<br/>(<%= link_to_sproutrb(event_id: 11019) %> と同時開催) |終了(22名参加)| 2014/06/28 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(761156757242034) %> |
 | Matsue.rb定例会H26.05(#51)    |終了(13名参加)| 2014/05/31 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(351258431683303) %> |
 | Matsue.rb定例会H26.04(#50)    |終了(15名参加)| 2014/04/26 9:30-17:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(745294255504952) %> |
-| 松江Ruby会議05                |終了(午前33名、午後40名参加)| 2014/03/15 11:00-13:00<br />2014/03/15 13:25-19:30<br /> | <%= link_to_osslab %> | 必要   |無料| <%= link_to("松江Ruby会議05", "/matrk05") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0050/0050-MatsueRubyKaigi05.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/642795") %><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi05") %> |
+| 松江Ruby会議05                |終了(午前33名、午後40名参加)| 2014/03/15 11:00-13:00<br />2014/03/15 13:25-19:30<br /> | <%= link_to_osslab %> | 必要   |無料| <%= link_to("松江Ruby会議05", "/matrk05") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0050/0050-MatsueRubyKaigi05.html")%><br /><%= link_to("Togetterまとめ", "http://togetter.com/li/642795") %> |
 | Matsue.rb定例会H26.02(#49)    |終了(24名参加)| 2014/02/08 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(605450046180950) %> |
 | Matsue.rb定例会H26.01(#48)    |終了(18名参加)| 2014/01/11 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(508877202553007) %> |
 
@@ -199,7 +199,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H24.12(#35)|終了    | 2012/12/08 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(308020945970668) %>|
 | Matsue.rb定例会H24.11(#34)|終了    | 2012/11/17 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(289218707863167) %>|
 | Matsue.rb定例会H24.10(#33)|終了    | 2012/10/20 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(344019002354189) %> |
-| 松江Ruby会議04           |終了(約120名参加)| 2012/09/01 10:00-17:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議04", "http://regional.rubykaigi.org/matsue04") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0040/0040-MatsueRubyKaigi04Report.html")%><br/><%= link_to("OSPN記事", "http://www.ospn.jp/press/20120914osc2012-shimane-report.html") %><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/osc-2012-shimane") %> |
+| 松江Ruby会議04           |終了(約120名参加)| 2012/09/01 10:00-17:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議04", "http://regional.rubykaigi.org/matsue04") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0040/0040-MatsueRubyKaigi04Report.html")%><br/><%= link_to("OSPN記事", "http://www.ospn.jp/press/20120914osc2012-shimane-report.html") %> |
 | Matsue.rb定例会H24.09(#32)<br />(松江Ruby会議04内)    |終了    | 2012/09/01 10:00-15:00 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(276110739164783) %> |
 | Matsue.rb定例会H24.08(#31)|終了    | 2012/08/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(339245126155975) %> |
 | Matsue.rb定例会H24.07(#30)|終了    | 2012/07/07 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(261114883994167) %> |
@@ -225,7 +225,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H23.10(#21)|終了    | 2011/10/29 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(234021273313564) %> |
 | Matsue.rb定例会H23.09(#20)|終了    | 2011/09/24 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(262547307101550) %> |
 | Matsue.rb定例会H23.08(#19)|終了    | 2011/08/28 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(135784423175244) %> |
-| 松江Ruby会議03            |終了(59名参加)| 2011/07/03 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議03", "http://regional.rubykaigi.org/matsue03") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0035/0035-MatsueRubyKaigi03Report.html")%><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi03") %> |
+| 松江Ruby会議03            |終了(59名参加)| 2011/07/03 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議03", "http://regional.rubykaigi.org/matsue03") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0035/0035-MatsueRubyKaigi03Report.html")%> |
 | Matsue.rb定例会H23.06(#18)|終了    | 2011/06/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料|<%= fbe(136465133098778) %> |
 | Matsue.rb定例会H23.05(#17)|終了    | 2011/05/28 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
 | Matsue.rb定例会H23.04(#16)|終了    | 2011/04/23 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
@@ -252,7 +252,7 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 | Matsue.rb定例会H22.05(#07) |終了(9名参加) | 2010/05/23 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
 | Matsue.rb定例会H22.04(#06) |終了    | 2010/04/25 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
 | Matsue.rb定例会H22.03(#05) |終了    | 2010/03/20 9:30-17:30 | <%= link_to_osslab %> | 不要   |無料| なし |
-| 松江Ruby会議02            |終了(74名参加)| 2010/02/13 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議02", "http://regional.rubykaigi.org/matsue02") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0034/0034-MatsueRubyKaigi02Report.html")%><br /><%= link_to("Ustream", "http://www.ustream.tv/channel/matsuerubykaigi02") %> |
+| 松江Ruby会議02            |終了(74名参加)| 2010/02/13 13:00-18:00 | 松江テルサ | 必要   |無料| <%= link_to("松江Ruby会議02", "http://regional.rubykaigi.org/matsue02") %><br /><%= link_to("るびま記事", "https://magazine.rubyist.net/articles/0034/0034-MatsueRubyKaigi02Report.html")%> |
 
 
 </div>


### PR DESCRIPTION
## 関連issue

#190

## 概要

Ustreamはサービス終了しているため、Matsue.rbの公式サイト内のUstreamの動画のリンクを削除しました。
動画がアップロードし直された場合、そちらのリンクを追加します。