### PR TITLE
tag_pageメソッド内のcreateメソッドの引数の指定で不要なオプションを削除

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -62,8 +62,7 @@ def tag_page
   tags = get_tags(@items)
   tags.each do |k, v|
     page_stats = {:title => "tag: #{k}", :tag_page_title => "#{k}"}
-    option = {:binary => false}
-    @items.create("<%= render('_tag') %>", page_stats, Nanoc::Identifier.new("/tags/#{k}/", type: :legacy), option)
+    @items.create("<%= render('_tag') %>", page_stats, Nanoc::Identifier.new("/tags/#{k}/", type: :legacy))
   end
 end
 


### PR DESCRIPTION
Ruby 2.7からメソッド呼び出しの引数の指定で、最後の引数がHashの場合にキーワード引数として扱うというのがdeprecatedが出力されていました。
Ruby 3.0で上記の仕様が削除されたため、bundle exec nanoc compile時にtag_pageメソッドが原因でエラーが発生してコンパイルに失敗します。

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

tag_pageメソッド内のcreateメソッドの指定でオプションを指定していますが、以下のnanoc内のコードを読むとデフォルト値と同じ値が指定されています。

https://github.com/nanoc/nanoc/blob/main/nanoc-core/lib/nanoc/core/mutable_item_collection_view.rb#L27

そのため、不要なオプション指定と思われるので削除しました。
オプション変更の指定もtag_pageメソッドを呼び出し時に変更できない状態ですが、これは必要になってから追加するということでそのままにしています。