### PR TITLE
Gemfileにpumaを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "guard-nanoc"
 gem "adsf"
 gem "minigit"
 gem "icalendar"
+gem "puma"
 
 group :development do
   gem "bundler-audit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       nanoc-cli (~> 4.11, >= 4.11.15)
       nanoc-core (~> 4.11, >= 4.11.15)
     nenv (0.3.0)
+    nio4r (2.5.5)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -97,6 +98,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
+    puma (5.2.1)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -143,10 +146,11 @@ DEPENDENCIES
   mime-types
   minigit
   nanoc (~> 4.11)
+  puma
   rack
   rb-fsevent
   rspec
   timecop
 
 BUNDLED WITH
-   2.0.1
+   2.2.3


### PR DESCRIPTION
Ruby 3.0でwebrickが標準ライブラリから削除されました。

> 以下のライブラリは標準添付ライブラリから削除されました。3.0 以降で使いたい場合は rubygems から利用してください。
>
>   webrick

https://www.ruby-lang.org/ja/news/2020/12/25/ruby-3-0-0-released/

その影響で `nanoc view` コマンドを実行時にサーバを立ち上げられませんでした。
`bundle view` コマンドの実行の失敗で表示されたメッセージに従い、webrickの代わりになるgemパッケージとしてpumaをインストールしました。