### PR TITLE
公式サイトのURLをHTTPSにする変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## はじめに
 
-これは、[Matsue.rb公式Webサイト](http://matsue.rubyist.net/)のソースコードです。
+これは、[Matsue.rb公式Webサイト](https://matsue.rubyist.net/)のソースコードです。
 
-[Matsue.rb公式Webサイト](http://matsue.rubyist.net/)は[nanoc](http://nanoc.ws/)を利用して構築しています。
+[Matsue.rb公式Webサイト](https://matsue.rubyist.net/)は[nanoc](http://nanoc.ws/)を利用して構築しています。
 
-また、[GitHub Pages](http://pages.github.com/)を利用して公開しています。rubyist.netのサブドメインとして、[matsue.rubyist.net](http://matsue.rubyist.net/)をいただいています。
+また、[GitHub Pages](http://pages.github.com/)を利用して公開しています。rubyist.netのサブドメインとして、[matsue.rubyist.net](https://matsue.rubyist.net/)をいただいています。
 
 本文書では、Matsue.rb公式Webサイトをメンテナンスするための情報や、コンテンツの制作に貢献するための情報を提供します。
 
@@ -39,7 +39,7 @@
 
 ## コンテンツ制作への貢献
 
-[Matsue.rb公式Webサイト](http://matsue.rubyist.net/)のコンテンツの制作を手伝っていただける方へ、そのやり方を説明します。少し長いですが、GitHubを利用したプロジェクトへの貢献手順の一般的な方法ですので、覚えて損はありません！！
+[Matsue.rb公式Webサイト](https://matsue.rubyist.net/)のコンテンツの制作を手伝っていただける方へ、そのやり方を説明します。少し長いですが、GitHubを利用したプロジェクトへの貢献手順の一般的な方法ですので、覚えて損はありません！！
 
 1. GitHubのアカウントを取得します。
 2. このレポジトリを[Fork](fork)します。
@@ -72,7 +72,7 @@
 
 ### グループのメンバー 一覧の更新
 
-Matsue.rbのメンバーの一覧を http://matsue.rubyist.net/members/ で公開しています。
+Matsue.rbのメンバーの一覧を https://matsue.rubyist.net/members/ で公開しています。
 メンバーの情報は、 [/resources/members.yml](https://github.com/matsuerb/matsuerb-nanoc/blob/master/resources/members.yml) で管理していますので、上記の「コンテンツ制作への貢献」を参考にして、このファイルを修正してpull requestを送ってください。
 
 ### お知らせの追加

--- a/layouts/_head.html
+++ b/layouts/_head.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="/css/sitecontents.css" />
 <% end %>
 <link rel="shortcut icon" href="/images/bn/favicon.ico" />
-<link rel="canonical" href="<%= File.join("http://http://matsue.rubyist.net", @item.path) %>" />
+<link rel="canonical" href="<%= File.join("https://matsue.rubyist.net", @item.path) %>" />
 <title><%= (t = @item[:title]) ? "#{t}|" : '' %>松江Ruby(Matsue.rb)</title>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <meta name="generator" content="nanoc <%= Nanoc::VERSION %>" />

--- a/layouts/matrk.html
+++ b/layouts/matrk.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= @item[:title] %> <%= @item[:date] %> <%= @item[:location] %>">
     <meta property="og:title" content="<%= @item[:title] %>">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="http://matsue.rubyist.net/">
+    <meta property="og:url" content="https://matsue.rubyist.net/">
     <meta property="og:description" content="<%= @item[:title] %> <%= @item[:date] %> <%= @item[:location] %>にて開催">
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>" />
     <link rel="stylesheet" href="/matrk_common/css/bootstrap.css">
@@ -21,7 +21,7 @@
 
     <!-- FOOTER -->
     <footer>
-      <p class="text-center"><a href="http://matsue.rubyist.net/"><img src="/matrk_common/img/h_logo.jpg" alt="matsuerb"></a></p>
+      <p class="text-center"><a href="https://matsue.rubyist.net/"><img src="/matrk_common/img/h_logo.jpg" alt="matsuerb"></a></p>
       <p class="text-center text-small">RubyロゴはYukihiro Matsumotoの著作物であり、Creative Commons BY-SAライセンスにより <a href="https://www.ruby-lang.org/ja/about/logo/">https://www.ruby-lang.org/ja/about/logo/</a> で公開されています。</p>
     </footer>
 

--- a/layouts/nxt_matrk.html
+++ b/layouts/nxt_matrk.html
@@ -7,7 +7,7 @@
     <meta name="description" content="<%= @item[:title] %> Coming Soon...">
     <meta property="og:title" content="<%= @item[:title] %>">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="http://matsue.rubyist.net/">
+    <meta property="og:url" content="https://matsue.rubyist.net/">
     <meta property="og:description" content="<%= @item[:title] %> Coming Soon...">
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>" />
     <link rel="stylesheet" href="/matrk_common/css/normalize.css">

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -83,4 +83,4 @@ watcher:
   notify_on_compilation_success: true
   notify_on_compilation_failure: true
 
-base_url: "http://matsue.rubyist.net"
+base_url: "https://matsue.rubyist.net"


### PR DESCRIPTION
## 概要

公式サイトのURLをHTTPからHTTPSに変更する変更です。
`http://matsue.rubyist.net/` から `https://matsue.rubyist.net/` です。

## Issue

https://github.com/matsuerb/matsuerb-nanoc/issues/757