### PR TITLE
Matsue.rb定例会についてを更新

### DIFF
--- a/content/about_us.html
+++ b/content/about_us.html
@@ -19,9 +19,9 @@ Matsue.rbの情報交換やイベントの告知は主にFacebookの<a href="htt
 
 ## Matsue.rb定例会について
 
-Matsue.rb定例会は、毎月1回、9:30から17:00まで<%= link_to_osslab %>で開催しているイベントです。
+Matsue.rb定例会は、『Rubyを中心にオープンソースソフトウェアに関する新しい発見や学びを共有できる場を提供し続ける』という目的で、毎月1回、13:00から17:00まで[松江オープンソースラボ](https://matsue.rubyist.net/map/)、[オンライン](https://github.com/matsuerb/matsuerb-nanoc/wiki/matsuerb-online)で開催しているイベントです。
 
-本イベントは、午前中から参加している人同士で昼食をとり、それ以外の時間は自由にRubyに関するなにかを行うというものです。参加時間も自由で午前中だけとか、午後だけとか、2時間だけとか、仕事の合間にRubyに関する質問をしにきたりとか。
+[当日の流れ](https://github.com/matsuerb/matsuerb-nanoc/wiki/matsuerb-online#%E6%B5%81%E3%82%8C)は決まっていますが、各自がもくもくと自由に何かをするというものです。参加時間も2時間だけとか、仕事の合間にRubyに関する質問をしにきたりとか、自由です。
 
 これまで、みなさんがMatsue.rbで取り組まれたことをざっと挙げてみます。参加するかどうかの判断の参考にしてくださいね。
 


### PR DESCRIPTION
## 概要

高尾さんからの提案で、Matsue.rb定例会についての説明が現状と合わないので更新しました。
