### PR TITLE
松江Ruby会議08プロコンリンク変更

### DIFF
--- a/content/matrk08/index.html
+++ b/content/matrk08/index.html
@@ -198,7 +198,7 @@ publish: true
       <p>
         プログラミングコンテストは11/24〜12/14が応募期間でした。<br>
         ご参加ありがとうございました。<br>
-        当時の<a href="http://procon2016.eastback.jp/solvers/">ランキングページ(別サイト)</a>は引き続きご覧になる事ができます。<br>
+        当時の<a href="https://matsue.rubyist.net/matrk08-procon/">ランキングページ(別サイト)</a>は引き続きご覧になる事ができます。<br>
       </p>
       <br>
       <h3>プログラミングコンテスト・RubyQuiz賞品</h3>


### PR DESCRIPTION
松江Ruby会議08のプログラミングコンテストのランキングページへのリンク先をAWS S3からGitHubページに変更する。