### PR TITLE
松江Ruby会議のフッターのCSSを削除

### DIFF
--- a/layouts/matrk.html
+++ b/layouts/matrk.html
@@ -17,7 +17,6 @@
     <link rel="stylesheet" href="/matrk_common/css/button.css">
     <link rel="stylesheet" href="/matrk_common/css/speaker.css">
     <link rel="stylesheet" href="/matrk_common/css/sponser.css">
-    <link rel="stylesheet" href="/matrk_common/css/footer.css">
     <link rel="stylesheet" href="/matrk_common/css/font.css">
     <link rel="stylesheet" href="<%= @item.identifier.to_s[/\/\w*\//] %>css/application.css">
   </head>

--- a/static/matrk_common/css/footer.css
+++ b/static/matrk_common/css/footer.css
@@ -1,9 +1,0 @@
-/* footer */
-footer {
-  margin: 50px 0 0 0;
-  padding: 20px 0;
-}
-
-footer p.text-small{
-  font-size: 11px;
-}


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/963