### PR TITLE
Bootstrapのデフォルトのフォントの指定を使用するので独自指定を削除

### DIFF
--- a/layouts/matrk.html
+++ b/layouts/matrk.html
@@ -16,7 +16,6 @@
     <link rel="stylesheet" href="/matrk_common/css/button.css">
     <link rel="stylesheet" href="/matrk_common/css/speaker.css">
     <link rel="stylesheet" href="/matrk_common/css/sponser.css">
-    <link rel="stylesheet" href="/matrk_common/css/font.css">
     <link rel="stylesheet" href="/matrk_common/css/matrk.css">
     <link rel="stylesheet" href="<%= @item.identifier.to_s[/\/\w*\//] %>css/application.css">
   </head>

--- a/static/css/matsuerb.css
+++ b/static/css/matsuerb.css
@@ -24,7 +24,6 @@ ul.menu li {
   margin: 0;
   padding: 0;
   text-align: center;
-  font-family: Helvetica , "游ゴシック体" , "Yu Gothic" , "メイリオ" ,sans-serif;
 }
 ul.menu li:first-child {
   position: relative;
@@ -316,6 +315,5 @@ iframe {
   }
    .table_schedule table td:before{
     color :#000;
-    font-family:"Osaka−等幅","ＭＳ ゴシック","monospace";
   }
 }

--- a/static/matrk_common/css/font.css
+++ b/static/matrk_common/css/font.css
@@ -1,4 +1,0 @@
-body {
-  font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", "Hiragino Sans", "BIZ UDPGothic", Meiryo, sans-serif;
-  color: #333;
-}


### PR DESCRIPTION
現在のBootstrapのフォントは  font-family が自動で設定されるので独自指定を削除しました。

> デフォルトのWebフォント（Helvetica Neue, Helvetica, Arial）はBootstrap4で廃止されました。
> デバイスとOSで最適なテキストのレンダリングを行うために”ネイティブ・フォントスタック”になりました。
>
> この font-family は <body> に適用されると, 自動的に全体に継承されます。 基本の font-family を切り替えるには, $font-family-base を変更して, コンパイルします。

https://getbootstrap.jp/docs/4.1/content/reboot/#native-font-stack