### PR TITLE
松江Ruby会議10の書籍プレゼントがスマホ版で横の表示が切れるので変更

### DIFF
--- a/content/matrk10/index.html
+++ b/content/matrk10/index.html
@@ -175,9 +175,9 @@ publish: true
       </div>
     </div>
     <div class="row">
-      <div class="col-md-12">
-        <div class="card" style="width: 26rem;">
-          <img alt="xware" src="img/book_cover.png" class="xware card-image-top">
+      <div class="col-md-4">
+        <div class="card">
+          <img alt="book" src="img/book_cover.png" class="card-image-top">
           <div class="card-body">
             <p class="card-text">
               RubyとRailsの学習ガイド2023 (25冊)<br />


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1013