### PR TITLE
不要な松江Ruby会議06と松江Ruby会議07の設定を削除

### DIFF
--- a/Rules
+++ b/Rules
@@ -35,21 +35,11 @@ compile '/tags/*/' do
   layout 'default'
 end
 
-compile '/matrk[0-1][0-1,5-9]/' do
+compile '/matrk[0-1][0-1,5-9]/*' do
   if item.binary?
     # don’t filter binary items
   else
     filter :erb, trim_mode: '-'
-    filter :kramdown
-    layout 'matrk'
-  end
-end
-
-compile '/matrk0[6-7]/*' do
-  if item.binary?
-    # don’t filter binary items
-  else
-    filter :erb
     filter :kramdown
     layout 'matrk'
   end


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1045