### PR TITLE
松江Ruby会議の参加登録ボタンのフォントの表示を変更

### DIFF
--- a/static/matrk_common/css/button.css
+++ b/static/matrk_common/css/button.css
@@ -1,8 +1,8 @@
 /* button */
 .button {
   padding: 10px 70px;
-  font-size: 25px;
-  line-height: 1.3;
+  font-size: 1.4em;
+  font-weight: bold;
   border-radius: 10px;
   color: #FFFFFF;
   background-color: #EB1D15;


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1070