### PR TITLE
松江Ruby会議のボタンのマウスオーバーした時のCSSの指定を追加

### DIFF
--- a/static/matrk_common/css/button.css
+++ b/static/matrk_common/css/button.css
@@ -12,6 +12,7 @@
   width: 295px
 }
 
+.button:hover,
 .matsuerb_logo:hover {
   -webkit-filter: saturate(136%);
   -moz-filter: saturate(136%);


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1070