### PR TITLE
松江Ruby会議06のライブコーディング大喜利の見出しの不要なアイコンを削除

### DIFF
--- a/content/matrk06/ogiri.html
+++ b/content/matrk06/ogiri.html
@@ -36,7 +36,7 @@ kind: matrk
   </div>
   <div id="flow" class="row py-3">
     <div class="col-md-12">
-      <h2><i class="glyphicon glyphicon-ok"></i> 流れ</h2>
+      <h2>流れ</h2>
       <ol>
         <li>最初に司会者からそれぞれに名前と所属と意気込みを聞きます。</li>
         <li>司会者がお題を提示　コーディング開始！</li>
@@ -50,7 +50,7 @@ kind: matrk
   </div>
   <div id="question" class="row py-3">
     <div class="col-md-12">
-      <h2><i class="glyphicon glyphicon-ok"></i> 問題</h2>
+      <h2>問題</h2>
     </div>
     <div id="question1" class="col-md-12 py-3">
       <h3>問 1 ランダムソート</h3>


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1041