### PR TITLE
松江Ruby会議10のGoogleカレンダのイベントの情報を追加

### DIFF
--- a/content/news/2023/09/16/matsue-rubykaigi10.html
+++ b/content/news/2023/09/16/matsue-rubykaigi10.html
@@ -7,6 +7,15 @@ publish: true
 tags: ["イベント"]
 changefreq: never
 priority: 0.5
+calendar:
+  year: 2023
+  month: 9
+  day: 16
+  summary: 松江Ruby会議10
+  description: 令和05年9月16日(土)に松江Ruby会議10を開催します。
+  start_time: "12:30"
+  end_time: "18:30"
+  location: 島根県松江市朝日町478番地18　松江テルサ別館2階
 ---
 
 2023/09/16（土）に松江Ruby会議10が松江オープンソースラボで開催されました。


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1216