### PR TITLE
松江Ruby会議09のGoogleカレンダのイベントの情報を追加

### DIFF
--- a/content/news/2018/11/20/matsue-rubykaigi09.html
+++ b/content/news/2018/11/20/matsue-rubykaigi09.html
@@ -7,6 +7,15 @@ publish: true
 tags: ["イベント"]
 changefreq: never
 priority: 0.5
+calendar:
+  year: 2018
+  month: 6
+  day: 30
+  summary: 松江Ruby会議09
+  description: 平成30年06月30日(土)に松江Ruby会議09を開催します。
+  start_time: "11:00"
+  end_time: "17:30"
+  location: 島根県松江市朝日町478番地18　松江テルサ別館2階
 ---
 
 2018/06/30（土）に松江Ruby会議09が松江オープンソースラボで開催されました。


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1216