### PR TITLE
松江Ruby会議08のGoogleカレンダのイベントの情報を追加

### DIFF
--- a/content/news/2018/07/18/matsue-rubykaigi08.html
+++ b/content/news/2018/07/18/matsue-rubykaigi08.html
@@ -7,6 +7,15 @@ publish: true
 tags: ["イベント"]
 changefreq: never
 priority: 0.5
+calendar:
+  year: 2016
+  month: 12
+  day: 17
+  summary: 松江Ruby会議08
+  description: 平成28年12月17日(土)に松江Ruby会議08を開催します。
+  start_time: "11:00"
+  end_time: "17:30"
+  location: 島根県松江市朝日町478番地18　松江テルサ4階大会議室
 ---
 
 2016/12/17（土）に松江Ruby会議08が松江テルサ４Ｆ大会議室で開催されました。


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1216