### PR TITLE
松江Ruby会議06のGoogleカレンダのイベントの情報を追加

### DIFF
--- a/content/news/2015/02/28/matsue-rubykaigi06.html
+++ b/content/news/2015/02/28/matsue-rubykaigi06.html
@@ -7,6 +7,15 @@ publish: true
 tags: ["イベント"]
 changefreq: never
 priority: 0.5
+calendar:
+  year: 2014
+  month: 12
+  day: 20
+  summary: 松江Ruby会議06
+  description: 平成26年12月20日(土)に松江Ruby会議06を開催します。
+  start_time: "13:00"
+  end_time: "17:45"
+  location: 島根県松江市朝日町478番地18　松江テルサ別館2階
 ---
 
 2014/12/20（土）に松江Ruby会議06がオープンソースラボで開催されました。


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1216