### PR TITLE
松江Ruby会議05のGoogleカレンダのイベントの情報を追加

### DIFF
--- a/content/news/2014/01/17/matrk05-ann.html
+++ b/content/news/2014/01/17/matrk05-ann.html
@@ -7,6 +7,15 @@ publish: true
 tags: ["イベント"]
 changefreq: never
 priority: 0.5
+calendar:
+  year: 2014
+  month: 3
+  day: 15
+  summary: 松江Ruby会議05
+  description: 平成26年3月15日(土)に松江Ruby会議05を開催します。
+  start_time: "11:00"
+  end_time: "19:30"
+  location: 島根県松江市朝日町478番地18　松江テルサ別館2階
 ---
 
 <p>　3月15日(土)に<%= link_to("松江Ruby会議05", "/matrk05") %>を開催します。場所は<%= link_to_osslab %>で、時間は11:00から13:00(午前の部)と13:25から19:30(午後の部)です。詳細はリンク先をご覧ください。</p>


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1216