### PR TITLE
松江Ruby会議12のXのリンクの表示で松江Ruby会議12以外のツイートが表示されないように変更

### DIFF
--- a/content/matrk12/index.html
+++ b/content/matrk12/index.html
@@ -71,7 +71,7 @@ kind: matrk
         </tr>
         <tr>
           <th>公式タグ</th>
-          <td>X(旧: Twitter): <a href="https://twitter.com/search?q=matrk12&src=typd&f=realtime" target="_blank">#matrk12</a></td>
+          <td>X(旧: Twitter): <a href="https://x.com/search?q=%23matrk12&src=typed_query" target="_blank">#matrk12</a></td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
https://github.com/matsuerb/matsuerb-nanoc/issues/1346